### PR TITLE
feat+docs: Added a streaming parser.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,12 @@ include = [
 ]
 
 [features]
-default = []
+default = ["std"]
 std = []
 
 [dev-dependencies]
 logos = "0.12.0"
-yap = { path = ".", features = ["std"] }
+
+[[example]]
+name = "streaming_parser"
+required-features = ["std"]

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -184,7 +184,7 @@ fn object(toks: &mut impl Tokens<Item = char>) -> Option<Result<HashMap<String, 
 
     // If we hit any errors above, return it.
     let Ok(values) = values else {
-        return Some(values)
+        return Some(values);
     };
 
     skip_whitespace(&mut *toks);

--- a/examples/streaming_parser.rs
+++ b/examples/streaming_parser.rs
@@ -1,0 +1,167 @@
+use std::{
+    fmt::Debug,
+    io::{stdin, Read},
+    iter::Iterator,
+    ops::Deref,
+    sync::{Arc, Mutex, Weak},
+};
+use yap::{TokenLocation, Tokens};
+
+type SharedBuffer<T> = Vec<Arc<T>>;
+
+#[derive(Clone, Debug)]
+pub struct BufferedTokens<I>
+where
+    I: Iterator,
+{
+    iter: I,
+    cursor: usize,
+    buffer: SharedBuffer<Option<I::Item>>,
+    /// - This list is used to broadcast new elements to all locations' buffers for when they are used to revert the iterator.
+    /// - Weak references to locations so that they can be dropped when only referenced here.
+    /// - The outer `Arc<Mutex<>>` is to get around the & in the location(&self) method.
+    locs: Arc<Mutex<Vec<Weak<Mutex<BufferedTokensLocation<I::Item>>>>>>,
+}
+
+/// Token location that stores the changes since it was created for when the iterator is reset.
+#[derive(Clone, Debug)]
+pub struct BufferedTokensLocation<Item> {
+    cursor: usize,
+    buffer: SharedBuffer<Option<Item>>,
+}
+
+/// Newtype to allow defining a TokenLocation.
+#[derive(Clone, Debug)]
+pub struct SharedBufferedTokensLocation<Item> {
+    inner: Arc<Mutex<BufferedTokensLocation<Item>>>,
+}
+
+impl<Item> Deref for SharedBufferedTokensLocation<Item> {
+    type Target = Arc<Mutex<BufferedTokensLocation<Item>>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<Item> From<Arc<Mutex<BufferedTokensLocation<Item>>>> for SharedBufferedTokensLocation<Item> {
+    fn from(value: Arc<Mutex<BufferedTokensLocation<Item>>>) -> Self {
+        Self { inner: value }
+    }
+}
+
+impl<I> TokenLocation for SharedBufferedTokensLocation<I> {
+    fn offset(&self) -> usize {
+        self.lock().unwrap().cursor
+    }
+}
+
+impl<I: Iterator> BufferedTokens<I> {
+    pub fn into_tokens(iter: I) -> Self {
+        BufferedTokens {
+            iter,
+            cursor: Default::default(),
+            buffer: Default::default(),
+            locs: Default::default(),
+        }
+    }
+}
+
+impl<I> Tokens for BufferedTokens<I>
+where
+    I: Iterator,
+    I::Item: Clone + Debug,
+{
+    type Item = I::Item;
+
+    type Location = SharedBufferedTokensLocation<I::Item>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.cursor += 1;
+        let mut locs = self.locs.lock().unwrap();
+        // If buffer has elements empty buffer before getting new elements.
+        if !self.buffer.is_empty() {
+            self.buffer.remove(0).as_ref().clone()
+        } else {
+            let next = self.iter.next();
+            let next_buffered = Arc::new(next.clone());
+            let mut i = 0;
+            while i < locs.len() {
+                if let Some(loc) = locs[i].upgrade() {
+                    loc.lock().unwrap().buffer.push(next_buffered.clone());
+                    i += 1;
+                } else {
+                    // Location order doesn't matter because they are all broadcast to for new elements.
+                    locs.swap_remove(i);
+                }
+            }
+            next
+        }
+    }
+
+    fn location(&self) -> Self::Location {
+        let loc = Arc::new(Mutex::new(BufferedTokensLocation {
+            cursor: self.cursor,
+            buffer: self.buffer.clone(),
+        }));
+        self.locs.lock().unwrap().push(Arc::downgrade(&loc));
+        loc.into()
+    }
+
+    fn set_location(&mut self, location: Self::Location) {
+        // Sets all value necessary to reset the iterator.
+        // It uses the location's store of buffered values.
+        // Notice that the `locs` doesn't need to be changed because all locations should stay subscribed.
+        let location = location.lock().unwrap();
+        self.cursor = location.cursor;
+        self.buffer = location.buffer.clone();
+    }
+
+    fn is_at_location(&self, location: &Self::Location) -> bool {
+        self.cursor == location.lock().unwrap().cursor
+    }
+}
+
+/// Takes two digits and adds them together. Fails if there are not two base 10 digits.
+fn parse_digit_pair(tokens: &mut impl Tokens<Item = u8>) -> Option<u32> {
+    let d1 = tokens.next()? as char;
+    let d2 = tokens.next()? as char;
+    // Return the result of adding the 2 digits we saw:
+    Some(d1.to_digit(10)? + d2.to_digit(10)?)
+}
+
+/// Parses a line ending of either "\r\n" (windows) or "\n" (linux)
+fn line_ending(tokens: &mut impl Tokens<Item = u8>) -> Option<&str> {
+    yap::one_of!(tokens;
+        tokens.optional(|t| t.tokens("\r\n".chars().map(|x| u8::try_from(x).unwrap())).then_some("\r\n")),
+        tokens.optional(|t| t.token(u8::try_from('\n').unwrap()).then_some("\n")),
+    )
+}
+
+fn main() {
+    let stdin = stdin().bytes().map(Result::unwrap);
+    let mut tokens = BufferedTokens::into_tokens(stdin);
+    // Set a location here to show how buffering works.
+    let start = tokens.location();
+    // Demonstrate streaming parsing of input.
+    // This is relatively painless and looks the same as a non-streaming parser because `BufferedTokens` handles buffering and `Bytes<Stdin>` handles blocking.
+    for line_of_digits in tokens.sep_by(
+        |t| Some(t.many(|t| parse_digit_pair(t)).collect::<Vec<_>>()),
+        |t| line_ending(t).is_some(),
+    ) {
+        println!("Line of digits: {:?}", line_of_digits);
+    }
+    // Reset location to show usage of internal buffer and freeing memory once the location doesn't need a diff buffer.
+    tokens.set_location(start);
+    let mut i = 0;
+    // Internal buffer is cleared since there are no longer locations which need the items.
+    loop {
+        i += 1;
+        // Speed up process by avoiding too many prints.
+        if i % 1000 == 0 {
+            eprintln!("Next: {:?}", tokens.next());
+        }
+        tokens.next();
+        tokens.buffer.shrink_to_fit();
+    }
+}

--- a/examples/streaming_parser.rs
+++ b/examples/streaming_parser.rs
@@ -1,167 +1,8 @@
 use std::{
-    collections::VecDeque,
-    fmt::Debug,
+    fmt::Display,
     io::{stdin, Read},
-    iter::Iterator,
-    sync::{Arc, Mutex},
 };
-use yap::{TokenLocation, Tokens};
-
-/// Buffer over items of an iterator.
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct Buffer<Item> {
-    oldest_elem_id: usize,
-    elements: VecDeque<Option<Item>>,
-    /// Sorted list of the oldest items needed per location
-    checkout: Vec<usize>,
-}
-
-impl<Item> Default for Buffer<Item> {
-    fn default() -> Self {
-        Self {
-            oldest_elem_id: Default::default(),
-            elements: Default::default(),
-            checkout: Default::default(),
-        }
-    }
-}
-
-/// Buffers over an iterator that can't itself be cloned.
-/// Enables parsing a stream of values such such as from a network socket or other realtime source.
-#[derive(Clone, Debug)]
-pub struct BufferedTokens<I>
-where
-    I: Iterator,
-{
-    iter: I,
-    cursor: usize,
-    /// Shared buffer of items and the id of the oldest item in the buffer.
-    buffer: Arc<Mutex<Buffer<I::Item>>>,
-}
-
-/// Token location that stores the changes since it was created for when the iterator is reset.
-#[derive(Clone, Debug)]
-pub struct BufferedTokensLocation<Item> {
-    cursor: usize,
-    buffer: Arc<Mutex<Buffer<Item>>>,
-}
-
-impl<Item> PartialEq for BufferedTokensLocation<Item> {
-    fn eq(&self, other: &Self) -> bool {
-        self.cursor == other.cursor && Arc::ptr_eq(&self.buffer, &other.buffer)
-    }
-}
-impl<Item> Eq for BufferedTokensLocation<Item> {}
-
-impl<Item> Drop for BufferedTokensLocation<Item> {
-    fn drop(&mut self) {
-        // Would rather not free memory then panic this thread because another panicked.
-        if let Ok(mut buf) = self.buffer.lock() {
-            let idx = buf
-                .checkout
-                .binary_search(&self.cursor)
-                .expect("missing entry for location in checkout");
-            buf.checkout.remove(idx);
-        }
-    }
-}
-
-impl<Item> TokenLocation for BufferedTokensLocation<Item> {
-    fn offset(&self) -> usize {
-        self.cursor
-    }
-}
-
-impl<I: Iterator> BufferedTokens<I> {
-    pub fn into_tokens(iter: I) -> Self {
-        BufferedTokens {
-            iter,
-            cursor: Default::default(),
-            buffer: Default::default(),
-        }
-    }
-}
-
-impl<I> Tokens for BufferedTokens<I>
-where
-    I: Iterator,
-    I::Item: Clone + Debug,
-{
-    type Item = I::Item;
-
-    type Location = BufferedTokensLocation<I::Item>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        self.cursor += 1;
-
-        // Try buffer
-        {
-            let buf = self.buffer.lock().expect("not poisoned");
-            // If buffer has elements use buffer before getting new elements.
-            if let Some(val) = buf.elements.get(self.cursor - buf.oldest_elem_id).cloned() {
-                return val;
-            }
-        }
-
-        // Clear buffer of old values
-        {
-            let mut buf = self.buffer.lock().expect("not poisoned");
-            // Remove old values no longer needed by any location
-            let min = match buf.checkout.first() {
-                Some(&x) => x.min(self.cursor),
-                None => self.cursor,
-            };
-            while (buf.oldest_elem_id < min) && (!buf.elements.is_empty()) {
-                buf.elements.pop_front();
-                buf.oldest_elem_id += 1;
-            }
-        }
-
-        // Handle cache miss
-        {
-            let next = self.iter.next();
-            let mut buf = self.buffer.lock().expect("not poisoned");
-            // Don't save to buffer if no locations exist which might need the value again
-            if buf.checkout.is_empty() {
-                return next;
-            } else {
-                buf.elements.push_back(next.clone());
-                next
-            }
-        }
-    }
-
-    fn location(&self) -> Self::Location {
-        // Checkout value at current location
-        let mut buf = self.buffer.lock().expect("not poisoned");
-        match buf.checkout.binary_search(&self.cursor) {
-            Ok(x) => buf.checkout.insert(x, self.cursor),
-            Err(x) => buf.checkout.insert(x, self.cursor),
-        };
-        BufferedTokensLocation {
-            cursor: self.cursor,
-            buffer: Arc::clone(&self.buffer),
-        }
-    }
-
-    fn set_location(&mut self, location: Self::Location) {
-        // Update cursor to new value
-        self.cursor = location.cursor;
-        // Location removes itself from checkout on drop
-    }
-
-    fn is_at_location(&self, location: &Self::Location) -> bool {
-        self.cursor == location.cursor
-    }
-}
-
-/// Takes two digits and adds them together. Fails if there are not two base 10 digits.
-fn parse_digit_pair(tokens: &mut impl Tokens<Item = u8>) -> Option<u32> {
-    let d1 = tokens.next()? as char;
-    let d2 = tokens.next()? as char;
-    // Return the result of adding the 2 digits we saw:
-    Some(d1.to_digit(10)? + d2.to_digit(10)?)
-}
+use yap::{types::StreamTokens, Tokens};
 
 /// Parses a line ending of either "\r\n" (windows) or "\n" (linux)
 fn line_ending(tokens: &mut impl Tokens<Item = u8>) -> Option<&'static str> {
@@ -171,33 +12,87 @@ fn line_ending(tokens: &mut impl Tokens<Item = u8>) -> Option<&'static str> {
     )
 }
 
-fn main() {
-    let stdin = stdin().bytes().map(Result::unwrap);
-    let mut tokens = BufferedTokens::into_tokens(stdin);
-    // Set a location here to show how buffering works.
-    let start = tokens.location();
-    // Demonstrate streaming parsing of input.
-    // This is relatively painless and looks the same as a non-streaming parser because `BufferedTokens` handles buffering and `Bytes<Stdin>` handles blocking.
-    // Parse pairs of digits into their sum. Stop parsing when a non-pair of digits is encountered.
-    for line_of_digits in tokens.sep_by(
-        |t| Some(t.many(|t| parse_digit_pair(t)).collect::<Vec<_>>()),
-        |t| line_ending(t).is_some(),
-    ) {
-        println!("Line of digits: {:?}", line_of_digits);
-    }
-    // Reset location to show usage of internal buffer and freeing memory once the location doesn't need a diff buffer.
-    tokens.set_location(start);
-    // Internal buffer is cleared since there are no longer locations which need the items.
-    while let Some(x) = tokens.as_iter().next() {
-        println!("Element: {x}");
-        if tokens
-            .buffer
-            .lock()
-            .expect("not poisoned")
-            .elements
-            .is_empty()
-        {
-            break;
+#[derive(Debug)]
+enum FizzBuzz {
+    Fizz,
+    Buzz,
+    FizzBuzz,
+    Neither,
+}
+
+impl Display for FizzBuzz {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FizzBuzz::Fizz => write!(f, "fizz"),
+            FizzBuzz::Buzz => write!(f, "buzz"),
+            FizzBuzz::FizzBuzz => write!(f, "fizzbuzz"),
+            FizzBuzz::Neither => write!(f, "neither"),
         }
     }
+}
+
+/// Takes two digits and adds them together. Fails if there are not two base 10 digits.
+fn fizzbuzz(x: u32) -> FizzBuzz {
+    if x % 5 == 0 && x % 3 == 0 {
+        FizzBuzz::FizzBuzz
+    } else if x % 3 == 0 {
+        FizzBuzz::Fizz
+    } else if x % 5 == 0 {
+        FizzBuzz::Buzz
+    } else {
+        FizzBuzz::Neither
+    }
+}
+
+/// An example program that parses stdin for numbers that match an output by the rules of fizzbuzz.
+/// It prints as it parses so the incremental parsing is more obvious.
+fn main() {
+    let stdin = stdin().bytes().map(Result::unwrap);
+    // Can't use `stdin.clone()` because it is over a stream of incoming values.
+    // If we could clone then [`IterTokens`] would be prefferable.
+    let mut tokens = StreamTokens::into_tokens(stdin);
+    let mut parsed_result = Vec::new();
+
+    println!("Lets play fizzbuzz! Enter a number. If it is divisible by three I'll say \"fizz\", \
+if it is divisible by five I'll say \"buzz\", and if it is divisible by both 3 and 5 I'll say \"fizzbuzz\".");
+
+    // Set a location to allow rewinding back to this point later.
+    // All items since the oldest location (`start` in this case) will be buffered
+    // so that a rewind to this point can occur with `set_location` if needed.
+    let start = tokens.location();
+
+    // Demonstrate streaming parsing of input.
+    // This is relatively painless and looks the same as a non-streaming parser.
+    // `StreamTokens` handles buffering and `Bytes<Stdin>` handles blocking in this case.
+    // The general form is some iterator over new input and wrapping that in `StreamTokens`
+    // to make that stream of items parseable.
+    for num in tokens.sep_by(
+        |t| {
+            Some(
+                t.tokens_while(|x| x.is_ascii_digit())
+                    .map(|x| x as char)
+                    .collect::<String>()
+                    .parse::<u32>(),
+            )
+        },
+        |t| line_ending(t).is_some(),
+    ) {
+        match num {
+            Ok(x) => {
+                let res = fizzbuzz(x);
+                println!("{}", res);
+                parsed_result.push(res)
+            }
+            Err(_) => println!("Ending parse on invalid u64"),
+        }
+    }
+
+    // Can use location to reset to previous values because they have been internally buffered
+    let previous_tokens = tokens
+        .slice(start, tokens.location())
+        .as_iter()
+        .map(|x| x as char)
+        .collect::<String>();
+    println!("You entered:\n{previous_tokens}");
+    println!("This parsed as: {parsed_result:?}");
 }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -999,7 +999,7 @@ mod test {
     fn test_many() {
         // No input:
         let mut t = "".into_tokens();
-        let abs: Vec<_> = t.many(|t| parse_ab(t)).collect();
+        let abs: Vec<_> = t.many(parse_ab).collect();
         let rest: Vec<char> = t.as_iter().collect();
 
         assert_eq!(abs.len(), 0);
@@ -1007,7 +1007,7 @@ mod test {
 
         // Invalid input after half is consumed:
         let mut t = "acabab".into_tokens();
-        let abs: Vec<_> = t.many(|t| parse_ab(t)).collect();
+        let abs: Vec<_> = t.many(parse_ab).collect();
         let rest: Vec<char> = t.as_iter().collect();
 
         assert_eq!(abs.len(), 0);
@@ -1015,7 +1015,7 @@ mod test {
 
         // 3 valid and then 1 half-invalid:
         let mut t = "abababaa".into_tokens();
-        let abs: Vec<_> = t.many(|t| parse_ab(t)).collect();
+        let abs: Vec<_> = t.many(parse_ab).collect();
         let rest: Vec<char> = t.as_iter().collect();
 
         assert_eq!(abs.len(), 3);
@@ -1023,7 +1023,7 @@ mod test {
 
         // End of tokens before can parse the fourth:
         let mut t = "abababa".into_tokens();
-        let abs: Vec<_> = t.many(|t| parse_ab(t)).collect();
+        let abs: Vec<_> = t.many(parse_ab).collect();
         let rest: Vec<char> = t.as_iter().collect();
 
         assert_eq!(abs.len(), 3);
@@ -1035,7 +1035,7 @@ mod test {
     fn test_many_err() {
         // No input:
         let mut t = "".into_tokens();
-        let abs: Vec<_> = t.many_err(|t| parse_ab_err(t)).collect();
+        let abs: Vec<_> = t.many_err(parse_ab_err).collect();
         let rest: Vec<char> = t.as_iter().collect();
 
         assert_eq!(abs, vec![Err(ABErr::NotEnoughTokens)]);
@@ -1043,7 +1043,7 @@ mod test {
 
         // Invalid input immediately:
         let mut t = "ccabab".into_tokens();
-        let abs: Vec<_> = t.many_err(|t| parse_ab_err(t)).collect();
+        let abs: Vec<_> = t.many_err(parse_ab_err).collect();
         let rest: Vec<char> = t.as_iter().collect();
 
         assert_eq!(abs, vec![Err(ABErr::IsNotA)]);
@@ -1051,7 +1051,7 @@ mod test {
 
         // Invalid input after half is consumed:
         let mut t = "acabab".into_tokens();
-        let abs: Vec<_> = t.many_err(|t| parse_ab_err(t)).collect();
+        let abs: Vec<_> = t.many_err(parse_ab_err).collect();
         let rest: Vec<char> = t.as_iter().collect();
 
         assert_eq!(abs, vec![Err(ABErr::IsNotB)]);
@@ -1059,7 +1059,7 @@ mod test {
 
         // 3 valid and then 1 half-invalid:
         let mut t = "abababaa".into_tokens();
-        let abs: Vec<_> = t.many_err(|t| parse_ab_err(t)).collect();
+        let abs: Vec<_> = t.many_err(parse_ab_err).collect();
         let rest: Vec<char> = t.as_iter().collect();
 
         assert_eq!(abs, vec![Ok(AB), Ok(AB), Ok(AB), Err(ABErr::IsNotB)]);
@@ -1067,7 +1067,7 @@ mod test {
 
         // End of tokens before can parse the fourth:
         let mut t = "abababa".into_tokens();
-        let abs: Vec<_> = t.many_err(|t| parse_ab_err(t)).collect();
+        let abs: Vec<_> = t.many_err(parse_ab_err).collect();
         let rest: Vec<char> = t.as_iter().collect();
 
         assert_eq!(
@@ -1101,25 +1101,25 @@ mod test {
     #[test]
     fn test_skip_many1() {
         let mut t = "".into_tokens();
-        let res = t.skip_many1(|t| parse_ab_err(t));
+        let res = t.skip_many1(parse_ab_err);
         let rest: String = t.as_iter().collect();
         assert_eq!(res, Err(ABErr::NotEnoughTokens));
         assert_eq!(&*rest, "");
 
         let mut t = "acabab".into_tokens();
-        let res = t.skip_many1(|t| parse_ab_err(t));
+        let res = t.skip_many1(parse_ab_err);
         let rest: String = t.as_iter().collect();
         assert_eq!(res, Err(ABErr::IsNotB));
         assert_eq!(&*rest, "acabab");
 
         let mut t = "abcbab".into_tokens();
-        let res = t.skip_many1(|t| parse_ab_err(t));
+        let res = t.skip_many1(parse_ab_err);
         let rest: String = t.as_iter().collect();
         assert_eq!(res, Ok(1));
         assert_eq!(&*rest, "cbab");
 
         let mut t = "ababcbab".into_tokens();
-        let res = t.skip_many1(|t| parse_ab_err(t));
+        let res = t.skip_many1(parse_ab_err);
         let rest: String = t.as_iter().collect();
         assert_eq!(res, Ok(2));
         assert_eq!(&*rest, "cbab");

--- a/src/types.rs
+++ b/src/types.rs
@@ -268,6 +268,229 @@ where
     }
 }
 
+#[cfg(feature = "std")]
+pub use stream_tokens::{StreamTokens, StreamTokensLocation};
+#[cfg(feature = "std")]
+mod stream_tokens {
+    use crate::{IntoTokens, TokenLocation, Tokens};
+    use std::{
+        collections::VecDeque,
+        fmt::Debug,
+        iter::Iterator,
+        sync::{Arc, Mutex},
+    };
+
+    /// Buffer over items of an iterator.
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct Buffer<Item> {
+        oldest_elem_id: usize,
+        elements: VecDeque<Option<Item>>,
+        /// Sorted list of the oldest items needed per location
+        checkout: Vec<usize>,
+    }
+
+    // Manual impl because Item: !Default also works.
+    impl<Item> Default for Buffer<Item> {
+        fn default() -> Self {
+            Self {
+                oldest_elem_id: Default::default(),
+                elements: Default::default(),
+                checkout: Default::default(),
+            }
+        }
+    }
+
+    /// Enables parsing a stream of values from an iterator that can't itself be cloned.
+    /// In order to be able to rewind the iterator it must save values since the last created [`StreamTokensLocation`]
+    #[derive(Clone, Debug)]
+    pub struct StreamTokens<I>
+    where
+        I: Iterator,
+    {
+        iter: I,
+        cursor: usize,
+        /// Shared buffer of items and the id of the oldest item in the buffer.
+        buffer: Arc<Mutex<Buffer<I::Item>>>,
+    }
+
+    /// This implements [`TokenLocation`] and stores the location. It also marks the [`Iterator::Item`]s
+    /// since it was created to be stored for when the corresponding [`StreamTokens`] is reset.
+    ///
+    /// The location is equivalent to `offset` in [`Iterator::nth(offset)`].
+    ///
+    /// The [`Drop`] implementation will un-mark that [`Iterator::Item`]s must be stored,
+    /// allowing the originating [`StreamTokens`] to drop old values and free memory.
+    #[derive(Debug)]
+    pub struct StreamTokensLocation<Item> {
+        cursor: usize,
+        buffer: Arc<Mutex<Buffer<Item>>>,
+    }
+
+    impl<Item> Clone for StreamTokensLocation<Item> {
+        fn clone(&self) -> Self {
+            // Checkout the cursor's position again
+            let mut buf = self.buffer.lock().expect("not poisoned");
+            let idx = match buf.checkout.binary_search(&self.cursor) {
+                Ok(x) | Err(x) => x,
+            };
+            buf.checkout.insert(idx, self.cursor);
+            // Then copy
+            Self {
+                cursor: self.cursor.clone(),
+                buffer: self.buffer.clone(),
+            }
+        }
+    }
+
+    impl<Item> PartialEq for StreamTokensLocation<Item> {
+        fn eq(&self, other: &Self) -> bool {
+            self.cursor == other.cursor
+        }
+    }
+    impl<Item> Eq for StreamTokensLocation<Item> {}
+
+    impl<Item> Drop for StreamTokensLocation<Item> {
+        fn drop(&mut self) {
+            // Would rather not free memory then panic this thread because another panicked.
+            if let Ok(mut buf) = self.buffer.lock() {
+                // Remove self.cursor from checkout.
+                let idx = buf
+                    .checkout
+                    .binary_search(&self.cursor)
+                    .expect("missing entry for location in checkout");
+                buf.checkout.remove(idx);
+            }
+        }
+    }
+
+    impl<Item> TokenLocation for StreamTokensLocation<Item> {
+        fn offset(&self) -> usize {
+            self.cursor
+        }
+    }
+
+    impl<I: Iterator> StreamTokens<I>
+    where
+        I::Item: Clone,
+    {
+        /// We can't define a blanket impl for [`IntoTokens`] on all `impl Iterator<Item: Clone>` without
+        /// [specialization](https://rust-lang.github.io/rfcs/1210-impl-specialization.html).
+        ///
+        /// Instead, use this method to convert a suitable iterator into [`Tokens`].
+        ///
+        /// # Example
+        ///
+        /// ```rust
+        /// use yap::{ Tokens, types::StreamTokens };
+        ///
+        /// // In normal usage, "hello \n\t world".into_tokens()
+        /// // would be preferred here (which would give StrTokens).
+        /// // This is just to demonstrate using StreamTokens:
+        /// let chars_iter = "hello \n\t world".chars();
+        /// let mut tokens = StreamTokens::into_tokens(chars_iter);
+        ///
+        /// // now we have tokens, we can do some parsing:
+        /// assert!(tokens.tokens("hello".chars()));
+        /// tokens.skip_tokens_while(|c| c.is_whitespace());
+        /// assert!(tokens.tokens("world".chars()));
+        /// ```
+        pub fn into_tokens(iter: I) -> Self {
+            StreamTokens {
+                iter,
+                cursor: Default::default(),
+                buffer: Default::default(),
+            }
+        }
+    }
+
+    impl<I> Tokens for StreamTokens<I>
+    where
+        I: Iterator,
+        I::Item: Clone + Debug,
+    {
+        type Item = I::Item;
+
+        type Location = StreamTokensLocation<I::Item>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.cursor += 1;
+
+            // Try buffer
+            {
+                let buf = self.buffer.lock().expect("not poisoned");
+                // If buffer has needed element use buffer before getting new elements.
+                if let Some(val) = buf
+                    .elements
+                    .get(self.cursor - 1 - buf.oldest_elem_id)
+                    .cloned()
+                {
+                    return val;
+                }
+            }
+
+            // Clear buffer of old values
+            {
+                let mut buf = self.buffer.lock().expect("not poisoned");
+                // Remove old values no longer needed by any location
+                let min = match buf.checkout.first() {
+                    Some(&x) => x.min(self.cursor),
+                    None => self.cursor,
+                };
+                while (buf.oldest_elem_id < min) && (!buf.elements.is_empty()) {
+                    buf.elements.pop_front();
+                    buf.oldest_elem_id += 1;
+                }
+            }
+
+            // Handle cache miss
+            {
+                let next = self.iter.next();
+                let mut buf = self.buffer.lock().expect("not poisoned");
+                // Don't save to buffer if no locations exist which might need the value again
+                if buf.checkout.is_empty() {
+                    next
+                } else {
+                    buf.elements.push_back(next.clone());
+                    next
+                }
+            }
+        }
+
+        fn location(&self) -> Self::Location {
+            // Checkout value at current location
+            let mut buf = self.buffer.lock().expect("not poisoned");
+            match buf.checkout.binary_search(&self.cursor) {
+                Ok(x) | Err(x) => buf.checkout.insert(x, self.cursor),
+            };
+            StreamTokensLocation {
+                cursor: self.cursor,
+                buffer: Arc::clone(&self.buffer),
+            }
+        }
+
+        fn set_location(&mut self, location: Self::Location) {
+            // Update cursor to new value
+            self.cursor = location.cursor;
+            // Location removes itself from checkout on drop
+        }
+
+        fn is_at_location(&self, location: &Self::Location) -> bool {
+            self.cursor == location.cursor
+        }
+    }
+
+    impl<I> IntoTokens<I::Item> for StreamTokens<I>
+    where
+        I: Iterator,
+        I::Item: Clone + core::fmt::Debug,
+    {
+        type Tokens = Self;
+        fn into_tokens(self) -> Self {
+            self
+        }
+    }
+}
+
 /// Embed some context with your [`Tokens`] implementation to
 /// access at any time. Use [`Tokens::with_context`] to produce this.
 pub struct WithContext<T, C> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -589,4 +589,25 @@ mod tests {
         tokens.set_location(loc);
         assert!(tokens.tokens("hello".chars()));
     }
+
+    #[test]
+    fn stream_tokens_sanity_check() {
+        // In reality, one should always prefer to use StrTokens for strings:
+        let chars: &mut dyn Iterator<Item = char> = &mut "hello \n\t world".chars();
+        // Can't `chars.clone()` so:
+        let mut tokens = StreamTokens::into_tokens(chars);
+
+        let loc = tokens.location();
+        assert!(tokens.tokens("hello".chars()));
+
+        tokens.set_location(loc.clone());
+        assert!(tokens.tokens("hello".chars()));
+
+        tokens.skip_tokens_while(|c| c.is_whitespace());
+
+        assert!(tokens.tokens("world".chars()));
+
+        tokens.set_location(loc);
+        assert!(tokens.tokens("hello".chars()));
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -591,6 +591,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn stream_tokens_sanity_check() {
         // In reality, one should always prefer to use StrTokens for strings:
         let chars: &mut dyn Iterator<Item = char> = &mut "hello \n\t world".chars();

--- a/src/types.rs
+++ b/src/types.rs
@@ -336,7 +336,7 @@ mod stream_tokens {
             buf.checkout.insert(idx, self.cursor);
             // Then copy
             Self {
-                cursor: self.cursor.clone(),
+                cursor: self.cursor,
                 buffer: self.buffer.clone(),
             }
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -302,7 +302,7 @@ mod stream_tokens {
 
     /// Enables parsing a stream of values from an iterator that can't itself be cloned.
     /// In order to be able to rewind the iterator it must save values since the oldest not [`Drop`]ed [`StreamTokensLocation`]
-    #[derive(Clone, Debug)]
+    #[derive(Debug)]
     pub struct StreamTokens<I>
     where
         I: Iterator,

--- a/src/types.rs
+++ b/src/types.rs
@@ -301,7 +301,7 @@ mod stream_tokens {
     }
 
     /// Enables parsing a stream of values from an iterator that can't itself be cloned.
-    /// In order to be able to rewind the iterator it must save values since the last created [`StreamTokensLocation`]
+    /// In order to be able to rewind the iterator it must save values since the oldest not [`Drop`]ed [`StreamTokensLocation`]
     #[derive(Clone, Debug)]
     pub struct StreamTokens<I>
     where


### PR DESCRIPTION
[Here](https://github.com/rosetta-rs/parse-rosetta-rs) it was indicated "?" for if this crate supports streaming input.
This is an example which shows that, yes, it does support this type of behavior. In fact, I believe that this can work better than the nom approach of allocating chunks and attempting to repeatedly parse while backing out every time there isn't enough data. The iterator can handle the buffering, blocking, and collecting of new elements as necessary so that no explicit backing out is necessary and it can simply block until the minimum number of needed items are available.
I doubt this implementation is the best that could exist but it should work fine as a demonstration.
While writing it seemed like it would be worth considering making `fn location(&self) -> Self::Location` into `fn location(&mut self) -> Self::Location`