### PR TITLE
Add generic Iterator Tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![API docs](https://docs.rs/yap/badge.svg)](https://docs.rs/yap)
 
-This small, zero-dependency crate helps you to parse input strings and slices by building on the `Iterator` 
-interface.
+This small, zero-dependency crate helps you to parse input strings, slices and (some) iterators of tokens
+by building on the `Iterator` interface.
 
 The aim of this crate is to provide the sorts of functions you'd come to expect from a parser
 combinator library, but without immersing you into a world of parser combinators, and forcing you
@@ -14,16 +14,16 @@ to sacrifice conciseness in exchange for simplicity.
 - Lots of examples. Every function provided comes with example usage.
 - Prioritise simplicity at the cost of verbosity.
 - Be iterator-centric. Where applicable, combinators return iterators, so you can lean on the `Iterator`
-  interface to parse as much or as little as you want from the input, and collect up the output however 
+  interface to parse as much or as little as you want from the input, and collect up the output however
   you wish.
 - Allow user defined errors to be returned anywhere that it might make sense. Some functions have `_err`
   variants incase you need error information when they don't otherwise hand back errors for simplicity.
 - Location information should always be available, so that you can tell users where something went wrong.
   see `Tokens::offset`
 - Backtracking by default. Coming from Haskell's Parsec, this feels like the sensible default. It means that
-  if one of the provided parsing functions fails to parse what you asked for, it won't consume any input 
+  if one of the provided parsing functions fails to parse what you asked for, it won't consume any input
   trying.
-- Expose all of the "low level" functions. You can save and rewind to locations as needed (see `Token::location`), 
+- Expose all of the "low level" functions. You can save and rewind to locations as needed (see `Token::location`),
   and implement ant of the provided functions using these primitives.
 - Aims to be "fairly quick". Avoids allocations (and allows you to do the same via the iterator-centric interface).
   If you need "as fast as you can get", there are probably quicker alternatives.
@@ -35,10 +35,10 @@ Have a look in the `examples` folder for more in depth examples.
 # Example
 
 ```rust
-use yap::{ 
+use yap::{
     // This trait has all of the parsing methods on it:
     Tokens,
-    // Allows you to use `.into_tokens()` on strings and slices, 
+    // Allows you to use `.into_tokens()` on strings and slices,
     // to get an instance of the above:
     IntoTokens
 };
@@ -79,7 +79,7 @@ let op_or_digit = tokens.sep_by_all(
     |t| t.surrounded_by(
         |t| parse_digits(t).map(OpOrDigit::Digit),
         |t| { t.skip_tokens_while(|c| c.is_ascii_whitespace()); }
-    ), 
+    ),
     |t| parse_op(t).map(OpOrDigit::Op)
 );
 
@@ -89,7 +89,7 @@ let mut current_digit = 0;
 for d in op_or_digit {
     match d {
         OpOrDigit::Op(op) => {
-            current_op = op 
+            current_op = op
         },
         OpOrDigit::Digit(n) => {
             match current_op {

--- a/src/types.rs
+++ b/src/types.rs
@@ -231,7 +231,7 @@ impl<I: Iterator + Clone> IterTokens<I> {
     /// tokens.skip_tokens_while(|c| c.is_whitespace());
     /// assert!(tokens.tokens("world".chars()));
     /// ```
-    pub fn from_iter(iter: I) -> Self {
+    pub fn into_tokens(iter: I) -> Self {
         IterTokens { iter, cursor: 0 }
     }
 }
@@ -351,7 +351,7 @@ mod tests {
     fn iterator_tokens_sanity_check() {
         // In reality, one should always prefer to use StrTokens for strings:
         let chars = "hello \n\t world".chars();
-        let mut tokens = IterTokens::from_iter(chars);
+        let mut tokens = IterTokens::into_tokens(chars);
 
         let loc = tokens.location();
         assert!(tokens.tokens("hello".chars()));

--- a/src/types.rs
+++ b/src/types.rs
@@ -224,7 +224,7 @@ impl<I: Iterator + Clone> IterTokens<I> {
     /// // would be preferred here (which would give StrTokens).
     /// // This is just to demonstrate using IterTokens:
     /// let chars_iter = "hello \n\t world".chars();
-    /// let mut tokens = IterTokens::from_iter(chars_iter);
+    /// let mut tokens = IterTokens::into_tokens(chars_iter);
     ///
     /// // now we have tokens, we can do some parsing:
     /// assert!(tokens.tokens("hello".chars()));

--- a/src/types.rs
+++ b/src/types.rs
@@ -188,7 +188,7 @@ pub struct IterTokens<I> {
 #[derive(Clone)]
 pub struct IterTokensLocation<I>(IterTokens<I>);
 
-impl <I> std::fmt::Debug for IterTokensLocation<I> {
+impl <I> core::fmt::Debug for IterTokensLocation<I> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "IterTokensLocation(cursor = {})", self.0.cursor)
     }
@@ -337,7 +337,6 @@ with_context_impls!(WithContextMut &mut);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{IntoTokens, Tokens};
 
     #[test]
     fn exotic_character_bounds() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -174,68 +174,91 @@ impl<'a> IntoTokens<char> for &'a str {
     }
 }
 
-/// This is what we are given back if we call [`IteratorTokens::into_tokens(iter)`] on
+/// This is what we are given back if we call [`IterTokens::into_tokens(iter)`] on
 /// an `impl Iterator + Clone`. It implements the [`Tokens`] interface.
-///
-/// [`IteratorTokens::into_tokens(iter)`]: struct.IteratorTokens.html#method.into_tokens
-#[derive(Clone, Debug)]
-pub struct IteratorTokens<I> {
+#[derive(Clone)]
+pub struct IterTokens<I> {
     iter: I,
     cursor: usize,
 }
 
 /// This implements [`TokenLocation`] and stores the location and state of
-/// our current cursor into some iterator. The location is equivalent to `offset` in [`Iterator::nth(offset)`].
-#[derive(Clone, Debug)]
-pub struct IteratorTokensLocation<I> {
-    state: IteratorTokens<I>,
-    cursor: usize,
+/// our current cursor into some iterator. The location is equivalent to `offset`
+/// in [`Iterator::nth(offset)`].
+#[derive(Clone)]
+pub struct IterTokensLocation<I>(IterTokens<I>);
+
+impl <I> std::fmt::Debug for IterTokensLocation<I> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "IterTokensLocation(cursor = {})", self.0.cursor)
+    }
 }
 
-impl<I> TokenLocation for IteratorTokensLocation<I> {
+// Locations match as long as the cursors do. This is as strong as the guarantee
+// for string or slice locations, and in all cases, locations from StrTokens/SliceTokens
+// may be equal even if the underlying tokens are different.
+impl <I> PartialEq for IterTokensLocation<I> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.cursor == other.0.cursor
+    }
+}
+
+impl<I> TokenLocation for IterTokensLocation<I> {
     fn offset(&self) -> usize {
-        self.cursor
+        self.0.cursor
     }
 }
 
-impl<I> IteratorTokens<I> {
-    /// Can't define a blanket impl for [`IntoTokens`] on all `impl Iterator + Clone` without [specialization](https://rust-lang.github.io/rfcs/1210-impl-specialization.html).
-    /// Instead use this and/or manually define [`IntoTokens`] for your specific iterator.
-    pub fn into_tokens(iter: I) -> Self {
-        IteratorTokens { iter, cursor: 0 }
+impl<I: Iterator + Clone> IterTokens<I> {
+    /// We can't define a blanket impl for [`IntoTokens`] on all `impl Iterator + Clone` without
+    /// [specialization](https://rust-lang.github.io/rfcs/1210-impl-specialization.html).
+    ///
+    /// Instead, use this method to convert a suitable iterator into [`Tokens`].
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use yap::{ Tokens, types::IterTokens };
+    ///
+    /// // In normal usage, "hello \n\t world".into_tokens()
+    /// // would be preferred here (which would give StrTokens).
+    /// // This is just to demonstrate using IterTokens:
+    /// let chars_iter = "hello \n\t world".chars();
+    /// let mut tokens = IterTokens::from_iter(chars_iter);
+    ///
+    /// // now we have tokens, we can do some parsing:
+    /// assert!(tokens.tokens("hello".chars()));
+    /// tokens.skip_tokens_while(|c| c.is_whitespace());
+    /// assert!(tokens.tokens("world".chars()));
+    /// ```
+    pub fn from_iter(iter: I) -> Self {
+        IterTokens { iter, cursor: 0 }
     }
 }
 
-impl<I> Tokens for IteratorTokens<I>
+impl<I> Tokens for IterTokens<I>
 where
     I: Iterator + Clone,
 {
     type Item = I::Item;
-
-    type Location = IteratorTokensLocation<I>;
+    type Location = IterTokensLocation<I>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.cursor += 1;
         self.iter.next()
     }
-
     fn location(&self) -> Self::Location {
-        IteratorTokensLocation {
-            state: self.clone(),
-            cursor: self.cursor,
-        }
+        IterTokensLocation(self.clone())
     }
-
     fn set_location(&mut self, location: Self::Location) {
-        *self = location.state;
+        *self = location.0;
     }
-
     fn is_at_location(&self, location: &Self::Location) -> bool {
-        self.cursor == location.cursor
+        self.cursor == location.0.cursor
     }
 }
 
-impl<I> IntoTokens<I::Item> for IteratorTokens<I>
+impl<I> IntoTokens<I::Item> for IterTokens<I>
 where
     I: Iterator + Clone,
 {
@@ -313,6 +336,7 @@ with_context_impls!(WithContextMut &mut);
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::{IntoTokens, Tokens};
 
     #[test]
@@ -322,5 +346,25 @@ mod tests {
         assert_eq!(tokens.next(), Some('🗻'));
         assert_eq!(tokens.next(), Some('∈'));
         assert_eq!(tokens.next(), Some('🌏'));
+    }
+
+    #[test]
+    fn iterator_tokens_sanity_check() {
+        // In reality, one should always prefer to use StrTokens for strings:
+        let chars = "hello \n\t world".chars();
+        let mut tokens = IterTokens::from_iter(chars);
+
+        let loc = tokens.location();
+        assert!(tokens.tokens("hello".chars()));
+
+        tokens.set_location(loc.clone());
+        assert!(tokens.tokens("hello".chars()));
+
+        tokens.skip_tokens_while(|c| c.is_whitespace());
+
+        assert!(tokens.tokens("world".chars()));
+
+        tokens.set_location(loc);
+        assert!(tokens.tokens("hello".chars()));
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -188,7 +188,7 @@ pub struct IterTokens<I> {
 #[derive(Clone)]
 pub struct IterTokensLocation<I>(IterTokens<I>);
 
-impl <I> core::fmt::Debug for IterTokensLocation<I> {
+impl<I> core::fmt::Debug for IterTokensLocation<I> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "IterTokensLocation(cursor = {})", self.0.cursor)
     }
@@ -197,7 +197,7 @@ impl <I> core::fmt::Debug for IterTokensLocation<I> {
 // Locations match as long as the cursors do. This is as strong as the guarantee
 // for string or slice locations, and in all cases, locations from StrTokens/SliceTokens
 // may be equal even if the underlying tokens are different.
-impl <I> PartialEq for IterTokensLocation<I> {
+impl<I> PartialEq for IterTokensLocation<I> {
     fn eq(&self, other: &Self) -> bool {
         self.0.cursor == other.0.cursor
     }


### PR DESCRIPTION
This builds off #8 (Thankyou @Easyoakland!) and adds an `IterTokens` interface to allow generic iterators of things to be used as `Tokens`.