### PR TITLE
Buffered parse

### DIFF
--- a/src/buffered.rs
+++ b/src/buffered.rs
@@ -164,16 +164,6 @@ mod test {
     use crate::{types::IterTokens, IntoTokens};
 
     #[test]
-    fn parse_unsigned() {
-        let a: u8 = ("123🗻∈🌏".into_tokens())
-            .as_buffered::<String>()
-            .digit()
-            .expect("NonEmpty")
-            .expect("Parse success");
-        assert_eq!(a, 123);
-    }
-
-    #[test]
     #[cfg(feature = "std")]
     fn parse_string() {
         let a: String = "123🗻∈🌏"
@@ -183,6 +173,17 @@ mod test {
             .expect("NonEmpty")
             .expect("Parse success");
         assert_eq!(a, "123🗻∈🌏");
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn parse_unsigned() {
+        let a: u8 = ("123🗻∈🌏".into_tokens())
+            .as_buffered::<String>()
+            .digit()
+            .expect("NonEmpty")
+            .expect("Parse success");
+        assert_eq!(a, 123);
     }
 
     #[test]

--- a/src/buffered.rs
+++ b/src/buffered.rs
@@ -1,0 +1,246 @@
+//! Collecting tokens into temporary buffers.
+
+use crate::Tokens;
+use core::{
+    array, iter,
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+    str::FromStr,
+};
+
+/// This is returned from [`Tokens::as_buffered()`], and exposes methods
+/// requiring temporary allocations on our tokens.
+pub struct BufferedTokens<'a, T, Buf> {
+    pub(crate) tokens: &'a mut T,
+    pub(crate) buf: PhantomData<Buf>,
+}
+
+impl<'a, T, Buf> BufferedTokens<'a, T, Buf>
+where
+    T: Tokens,
+    Buf: FromIterator<T::Item> + Deref<Target = str>,
+{
+    /// Use [`str::parse`] to parse the next `n` elements.
+    /// [`None`] if this is 0 elements.
+    pub fn parse_n<O>(&mut self, n: usize) -> Option<Result<O, <O as FromStr>::Err>>
+    where
+        O: FromStr,
+    {
+        let to_parse = self.tokens.as_iter().take(n).collect::<Buf>();
+        (!to_parse.is_empty()).then(|| to_parse.parse::<O>())
+    }
+
+    /// Use [`str::parse`] to parse the remaining elements until the next [`None`].
+    /// [`None`] if this is 0 elements.
+    pub fn parse_remaining<O>(&mut self) -> Option<Result<O, <O as FromStr>::Err>>
+    where
+        O: FromStr,
+    {
+        let to_parse = self.tokens.as_iter().collect::<Buf>();
+        (!to_parse.is_empty()).then(|| to_parse.parse::<O>())
+    }
+
+    /// Use [`str::parse`] to parse the next chunk of input matching a predicate.
+    /// [`None`] if this is 0 elements.
+    pub fn parse_while<O, F>(&mut self, take_while: F) -> Option<Result<O, <O as FromStr>::Err>>
+    where
+        O: FromStr,
+        F: FnMut(&T::Item) -> bool,
+    {
+        let to_parse = self.tokens.tokens_while(take_while).collect::<Buf>();
+        (!to_parse.is_empty()).then(|| to_parse.parse::<O>())
+    }
+}
+
+impl<'a, T, Buf> BufferedTokens<'a, T, Buf>
+where
+    T: Tokens<Item = char>,
+    Buf: FromIterator<T::Item> + Deref<Target = str>,
+{
+    /// Parse digits.
+    pub fn digit<O>(&mut self) -> Option<Result<O, <O as FromStr>::Err>>
+    where
+        O: FromStr,
+    {
+        self.parse_while(|t| t.is_numeric())
+    }
+
+    /// Parses digits with a sign (`+`/`-`) in front.
+    pub fn signed_digit<O>(&mut self) -> Option<Result<O, <O as FromStr>::Err>>
+    where
+        O: FromStr,
+    {
+        let loc = self.tokens.location();
+        let sign = self.tokens.next()?;
+        match sign {
+            '+' | '-' => {
+                let to_parse = iter::once(sign)
+                    .chain(self.tokens.tokens_while(|&t| t.is_numeric()))
+                    .collect::<Buf>();
+                (!to_parse.is_empty()).then(|| to_parse.parse::<O>())
+            }
+            _ => {
+                self.tokens.set_location(loc);
+                None
+            }
+        }
+    }
+
+    /// Parses alphabetical characters.
+    pub fn alpha<O>(&mut self) -> Option<Result<O, <O as FromStr>::Err>>
+    where
+        O: FromStr,
+    {
+        self.parse_while(|t| t.is_alphabetic())
+    }
+
+    /// Parses alphanumeric characters.
+    pub fn alphanumeric<O>(&mut self) -> Option<Result<O, <O as FromStr>::Err>>
+    where
+        O: FromStr,
+    {
+        self.parse_while(|t| t.is_alphanumeric())
+    }
+}
+
+/// A type that can collect [`u8`] on the stack to be used to [`str::parse`].
+/// Requires a max buffer size at compile time.
+/// # Panics
+/// - Collecting more items than the buffer's max size causes a panic.
+/// - Invalid-Utf8 will panic when dereferencing to a [`str`].
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct StackString<const N: usize> {
+    buf: [u8; N],
+    len: usize,
+}
+
+impl<const N: usize> Default for StackString<N> {
+    fn default() -> Self {
+        Self {
+            buf: array::from_fn(|_| Default::default()),
+            len: Default::default(),
+        }
+    }
+}
+
+impl<I: Into<u8>, const N: usize> FromIterator<I> for StackString<N> {
+    /// Creates a [`StackString`] from an iterator.
+    /// # Panics
+    /// Panics if the iterator is longer than the internal buffer of the [`StackString`]
+    fn from_iter<T: IntoIterator<Item = I>>(iter: T) -> Self {
+        let mut out = Self::default();
+        for (i, val) in iter.into_iter().enumerate() {
+            assert!(i < N, "Iterator longer than max buffer length ({N})");
+            out.buf[i] = val.into();
+            out.len += 1;
+        }
+        out
+    }
+}
+
+impl<const N: usize> Deref for StackString<N> {
+    type Target = str;
+
+    /// Dereferences the stack string to a `&str`.
+    /// # Panics
+    /// - If the [`StackString`] holds invalid Utf8.
+    fn deref(&self) -> &Self::Target {
+        core::str::from_utf8(&self.buf[..self.len]).expect("Valid Utf8")
+    }
+}
+
+impl<const N: usize> DerefMut for StackString<N> {
+    /// Dereferences the stack string to a `&mut str`.
+    /// # Panics
+    /// - If the [`StackString`] holds invalid Utf8.
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        core::str::from_utf8_mut(&mut self.buf[..self.len]).expect("Valid Utf8")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{types::IterTokens, IntoTokens};
+
+    #[test]
+    fn parse_unsigned() {
+        let a: u8 = ("123🗻∈🌏".into_tokens())
+            .as_buffered::<String>()
+            .digit()
+            .expect("NonEmpty")
+            .expect("Parse success");
+        assert_eq!(a, 123);
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn parse_string() {
+        let a: String = "123🗻∈🌏"
+            .into_tokens()
+            .as_buffered::<String>()
+            .parse_remaining()
+            .expect("NonEmpty")
+            .expect("Parse success");
+        assert_eq!(a, "123🗻∈🌏");
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn parse_signed() {
+        let a: u8 = "+123"
+            .into_tokens()
+            .as_buffered::<String>()
+            .parse_n(3)
+            .expect("NonEmpty")
+            .expect("Parse success");
+        assert_eq!(a, 12);
+        let a: i8 = "+123"
+            .into_tokens()
+            .as_buffered::<String>()
+            .parse_n(3)
+            .expect("NonEmpty")
+            .expect("Parse success");
+        assert_eq!(a, 12);
+        let a: i8 = "-123"
+            .into_tokens()
+            .as_buffered::<String>()
+            .signed_digit()
+            .expect("NonEmpty")
+            .expect("Parse success");
+        assert_eq!(a, -123);
+    }
+
+    #[test]
+    fn parse_stack() {
+        let a: i32 = IterTokens::into_tokens("-123456789🗻∈🌏".bytes())
+            .as_buffered::<StackString<10>>()
+            .parse_n(10)
+            .expect("NonEmpty")
+            .expect("Parse success");
+        assert_eq!(a, -123456789);
+        let a: i32 = IterTokens::into_tokens("-123456789🗻∈🌏".bytes())
+            .as_buffered::<StackString<20>>()
+            .parse_n(10)
+            .expect("NonEmpty")
+            .expect("Parse success");
+        assert_eq!(a, -123456789);
+    }
+
+    #[test]
+    fn parse_empty() {
+        assert!(IterTokens::into_tokens("".bytes())
+            .as_buffered::<StackString<0>>()
+            .parse_remaining::<u8>()
+            .is_none())
+    }
+
+    #[test]
+    fn parse_fail() {
+        assert!(IterTokens::into_tokens("256".bytes())
+            .as_buffered::<StackString<3>>()
+            .parse_remaining::<u8>()
+            .expect("NonEmpty")
+            .is_err())
+    }
+}

--- a/src/buffered.rs
+++ b/src/buffered.rs
@@ -16,7 +16,7 @@ pub struct BufferedTokens<'a, T> {
 impl<'a, T> BufferedTokens<'a, T>
 where
     T: Tokens,
-    for<'buf> T::Buffer<'buf>: Deref<Target = str>,
+    T::Buffer: Deref<Target = str>,
 {
     /// Use [`str::parse`] to parse the next `n` elements.
     /// [`None`] if this is 0 elements.
@@ -129,7 +129,7 @@ where
 impl<'a, T> BufferedTokens<'a, T>
 where
     T: Tokens<Item = char>,
-    for<'buf> T::Buffer<'buf>: Deref<Target = str>,
+    T::Buffer: Deref<Target = str>,
 {
     /// Parse next chunk of digits.
     /// # Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,5 +115,6 @@ assert_eq!(remaining, ",foobar");
 mod one_of;
 mod tokens;
 
+pub mod buffered;
 pub mod types;
 pub use tokens::{IntoTokens, TokenLocation, Tokens};

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -118,7 +118,8 @@ pub trait Tokens: Sized {
 
     /// Return a [`BufferedTokens`] over our tokens. This is exposes methods that require allocating to a buffer.
     /// It is generic over the buffer so one can use a heap allocated type (ex. [`std::string::String`](https://doc.rust-lang.org/std/string/struct.String.html))
-    /// or a stack allocated type (ex. [`heapless::String`](https://docs.rs/heapless/latest/heapless/struct.String.html)).
+    /// or a stack allocated type (ex. [`heapless::String`](https://docs.rs/heapless/latest/heapless/struct.String.html) or [`crate::buffered::StackString`]).
+    /// If a buffer of tokens is needed directly use `tokens.as_iter().collect()`.
     fn as_buffered<Buf>(&'_ mut self) -> BufferedTokens<'_, Self, Buf> {
         BufferedTokens {
             tokens: self,

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -38,9 +38,7 @@ pub trait Tokens: Sized {
     type Item;
 
     /// The type returned from [`Tokens::get_buffer()`]
-    type Buffer<'buf>
-    where
-        Self: 'buf;
+    type Buffer;
 
     /// An object which can be used to reset the token stream
     /// to some position.
@@ -118,7 +116,7 @@ pub trait Tokens: Sized {
     /// [`Tokens`] implementations that already have in-memory representation of the tokens should return references to that without copying.
     ///
     /// [`Tokens`] implementations that don't have in-memory representations of the tokens may need to copy or allocate.
-    fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer<'_>;
+    fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer;
 
     /// Return an iterator over our tokens. The [`Tokens`] trait already mirrors the [`Iterator`]
     /// interface by providing [`Tokens::Item`] and [`Tokens::next()`], but we allow the [`Iterator`]

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -126,7 +126,7 @@ pub trait Tokens: Sized {
         TokensIter { tokens: self }
     }
 
-    /// Return a [`BufferedTokens`] over our tokens. This is exposes methods that require an in-memory buffer of our tokens.
+    /// Return a [`BufferedTokens`] over our tokens. This exposes methods that require an in-memory buffer of our tokens.
     /// If a buffer of tokens is needed directly use [`Tokens::get_buffer`].
     fn as_buffered(&mut self) -> BufferedTokens<'_, Self> {
         BufferedTokens { tokens: self }

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -116,19 +116,19 @@ pub trait Tokens: Sized {
     /// [`Tokens`] implementations that already have in-memory representation of the tokens should return references to that without copying.
     ///
     /// [`Tokens`] implementations that don't have in-memory representations of the tokens may need to copy or allocate.
-    fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer;
+    fn get_buffer(&mut self, start: Self::Location, end: Self::Location) -> Self::Buffer;
 
     /// Return an iterator over our tokens. The [`Tokens`] trait already mirrors the [`Iterator`]
     /// interface by providing [`Tokens::Item`] and [`Tokens::next()`], but we allow the [`Iterator`]
     /// methods to be kept separate to avoid collisions, and because some iterator methods don't
     /// consume tokens as you might expect, and so must be used with care when parsing input.
-    fn as_iter(&'_ mut self) -> TokensIter<'_, Self> {
+    fn as_iter(&mut self) -> TokensIter<'_, Self> {
         TokensIter { tokens: self }
     }
 
     /// Return a [`BufferedTokens`] over our tokens. This is exposes methods that require an in-memory buffer of our tokens.
     /// If a buffer of tokens is needed directly use [`Tokens::get_buffer`].
-    fn as_buffered(&'_ mut self) -> BufferedTokens<'_, Self> {
+    fn as_buffered(&mut self) -> BufferedTokens<'_, Self> {
         BufferedTokens { tokens: self }
     }
 
@@ -249,7 +249,7 @@ pub trait Tokens: Sized {
     /// assert_eq!(s.next(), Some('o'));
     /// assert_eq!(s.next(), Some('p'));
     /// ```
-    fn slice(&'_ mut self, from: Self::Location, to: Self::Location) -> Slice<'_, Self> {
+    fn slice(&mut self, from: Self::Location, to: Self::Location) -> Slice<'_, Self> {
         Slice::new(self, self.location(), from, to)
     }
 
@@ -435,7 +435,7 @@ pub trait Tokens: Sized {
     /// // whereas `tokens_while` did not:
     /// assert_eq!(s.remaining(), "bc");
     /// ```
-    fn tokens_while<F>(&'_ mut self, f: F) -> TokensWhile<'_, Self, F>
+    fn tokens_while<F>(&mut self, f: F) -> TokensWhile<'_, Self, F>
     where
         F: FnMut(&Self::Item) -> bool,
     {
@@ -522,7 +522,7 @@ pub trait Tokens: Sized {
     /// assert_eq!(digits_iter.next(), None);
     /// assert_eq!(s.remaining(), "5abcde");
     /// ```
-    fn many_err<F, Output, E>(&'_ mut self, parser: F) -> ManyErr<'_, Self, F>
+    fn many_err<F, Output, E>(&mut self, parser: F) -> ManyErr<'_, Self, F>
     where
         F: FnMut(&mut Self) -> Result<Output, E>,
     {
@@ -627,7 +627,7 @@ pub trait Tokens: Sized {
     /// assert_eq!(digits, vec![1,2,3,4]);
     /// assert_eq!(s.remaining(), ",abc");
     /// ```
-    fn sep_by<F, S, Output>(&'_ mut self, parser: F, separator: S) -> SepBy<'_, Self, F, S>
+    fn sep_by<F, S, Output>(&mut self, parser: F, separator: S) -> SepBy<'_, Self, F, S>
     where
         F: FnMut(&mut Self) -> Option<Output>,
         S: FnMut(&mut Self) -> bool,
@@ -661,11 +661,7 @@ pub trait Tokens: Sized {
     /// assert_eq!(digits_iter.next(), None);
     /// assert_eq!(s.remaining(), ",a,1,2,3");
     /// ```
-    fn sep_by_err<F, S, E, Output>(
-        &'_ mut self,
-        parser: F,
-        separator: S,
-    ) -> SepByErr<'_, Self, F, S>
+    fn sep_by_err<F, S, E, Output>(&mut self, parser: F, separator: S) -> SepByErr<'_, Self, F, S>
     where
         F: FnMut(&mut Self) -> Result<Output, E>,
         S: FnMut(&mut Self) -> bool,
@@ -720,7 +716,7 @@ pub trait Tokens: Sized {
     /// assert_eq!(s.remaining(), "+abc");
     /// ```
     fn sep_by_all<F, S, Output>(
-        &'_ mut self,
+        &mut self,
         parser: F,
         separator: S,
     ) -> SepByAll<'_, Self, F, S, Output>
@@ -779,7 +775,7 @@ pub trait Tokens: Sized {
     /// assert_eq!(s.remaining(), "+abc");
     /// ```
     fn sep_by_all_err<F, S, Output, E>(
-        &'_ mut self,
+        &mut self,
         parser: F,
         separator: S,
     ) -> SepByAllErr<'_, Self, F, S, Output>

--- a/src/tokens/slice.rs
+++ b/src/tokens/slice.rs
@@ -56,7 +56,7 @@ impl<'a, T: Tokens> Tokens for Slice<'a, T> {
     fn is_at_location(&self, location: &Self::Location) -> bool {
         self.tokens.is_at_location(location)
     }
-    fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer {
+    fn get_buffer(&mut self, start: Self::Location, end: Self::Location) -> Self::Buffer {
         self.tokens.get_buffer(start, end)
     }
 }

--- a/src/tokens/slice.rs
+++ b/src/tokens/slice.rs
@@ -29,7 +29,7 @@ impl<'a, T: Tokens> Slice<'a, T> {
 // We can also treat this slice of tokens as tokens, too:
 impl<'a, T: Tokens> Tokens for Slice<'a, T> {
     type Item = T::Item;
-    type Buffer<'buf> = T::Buffer<'buf> where Self: 'buf;
+    type Buffer = T::Buffer;
     type Location = T::Location;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -56,7 +56,7 @@ impl<'a, T: Tokens> Tokens for Slice<'a, T> {
     fn is_at_location(&self, location: &Self::Location) -> bool {
         self.tokens.is_at_location(location)
     }
-    fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer<'_> {
+    fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer {
         self.tokens.get_buffer(start, end)
     }
 }

--- a/src/tokens/slice.rs
+++ b/src/tokens/slice.rs
@@ -29,6 +29,7 @@ impl<'a, T: Tokens> Slice<'a, T> {
 // We can also treat this slice of tokens as tokens, too:
 impl<'a, T: Tokens> Tokens for Slice<'a, T> {
     type Item = T::Item;
+    type Buffer<'buf> = T::Buffer<'buf> where Self: 'buf;
     type Location = T::Location;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -54,6 +55,9 @@ impl<'a, T: Tokens> Tokens for Slice<'a, T> {
     }
     fn is_at_location(&self, location: &Self::Location) -> bool {
         self.tokens.is_at_location(location)
+    }
+    fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer<'_> {
+        self.tokens.get_buffer(start, end)
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -45,7 +45,7 @@ impl<'a, Item> From<SliceTokens<'a, Item>> for &'a [Item] {
 
 impl<'a, Item> Tokens for SliceTokens<'a, Item> {
     type Item = &'a Item;
-    type Buffer<'buf> = &'buf [Item] where Self: 'buf;
+    type Buffer = &'a [Item];
     type Location = SliceTokensLocation;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -62,7 +62,7 @@ impl<'a, Item> Tokens for SliceTokens<'a, Item> {
     fn is_at_location(&self, location: &Self::Location) -> bool {
         self.cursor == location.0
     }
-    fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer<'_> {
+    fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer {
         &self.slice[start.0..end.0]
     }
 }
@@ -124,7 +124,7 @@ impl<'a> From<StrTokens<'a>> for &'a str {
 
 impl<'a> Tokens for StrTokens<'a> {
     type Item = char;
-    type Buffer<'buf> = &'buf str where Self: 'buf;
+    type Buffer = &'a str;
     type Location = StrTokensLocation;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -161,7 +161,7 @@ impl<'a> Tokens for StrTokens<'a> {
     fn is_at_location(&self, location: &Self::Location) -> bool {
         self.cursor == location.0
     }
-    fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer<'_> {
+    fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer {
         // Shouldn't panic if a location is derived from this StrTokens because all returned locations should be on valid char boundaries.
         &self.str[start.0..end.0]
     }
@@ -277,7 +277,7 @@ where
     Buf: FromIterator<I::Item>,
 {
     type Item = I::Item;
-    type Buffer<'buf> = Buf where Self: 'buf;
+    type Buffer = Buf;
     type Location = IterTokensLocation<I, Buf>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -293,7 +293,7 @@ where
     fn is_at_location(&self, location: &Self::Location) -> bool {
         self.cursor == location.0.cursor
     }
-    fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer<'_> {
+    fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer {
         let original = self.location();
         let delta = end.0.cursor - start.0.cursor;
         self.set_location(start);
@@ -359,7 +359,7 @@ macro_rules! with_context_impls {
         impl <T, C> Tokens for $name<$( $($mut)+ )? T, C>
         where T: Tokens {
             type Item = T::Item;
-            type Buffer<'buf> = T::Buffer<'buf> where Self: 'buf;
+            type Buffer = T::Buffer;
             type Location = T::Location;
 
             fn next(&mut self) -> Option<Self::Item> {
@@ -374,7 +374,7 @@ macro_rules! with_context_impls {
             fn is_at_location(&self, location: &Self::Location) -> bool {
                 self.tokens.is_at_location(location)
             }
-            fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer<'_> {
+            fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer {
                 self.tokens.get_buffer(start, end)
             }
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -62,7 +62,7 @@ impl<'a, Item> Tokens for SliceTokens<'a, Item> {
     fn is_at_location(&self, location: &Self::Location) -> bool {
         self.cursor == location.0
     }
-    fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer {
+    fn get_buffer(&mut self, start: Self::Location, end: Self::Location) -> Self::Buffer {
         &self.slice[start.0..end.0]
     }
 }
@@ -161,7 +161,7 @@ impl<'a> Tokens for StrTokens<'a> {
     fn is_at_location(&self, location: &Self::Location) -> bool {
         self.cursor == location.0
     }
-    fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer {
+    fn get_buffer(&mut self, start: Self::Location, end: Self::Location) -> Self::Buffer {
         // Shouldn't panic if a location is derived from this StrTokens because all returned locations should be on valid char boundaries.
         &self.str[start.0..end.0]
     }
@@ -293,7 +293,7 @@ where
     fn is_at_location(&self, location: &Self::Location) -> bool {
         self.cursor == location.0.cursor
     }
-    fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer {
+    fn get_buffer(&mut self, start: Self::Location, end: Self::Location) -> Self::Buffer {
         let original = self.location();
         let delta = end.0.cursor - start.0.cursor;
         self.set_location(start);
@@ -374,7 +374,7 @@ macro_rules! with_context_impls {
             fn is_at_location(&self, location: &Self::Location) -> bool {
                 self.tokens.is_at_location(location)
             }
-            fn get_buffer(&'_ mut self, start: Self::Location, end: Self::Location) -> Self::Buffer {
+            fn get_buffer(&mut self, start: Self::Location, end: Self::Location) -> Self::Buffer {
                 self.tokens.get_buffer(start, end)
             }
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -387,7 +387,7 @@ with_context_impls!(WithContextMut &mut);
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::buffered::StackString;
+    use crate::buffered::ArrayString;
 
     #[test]
     fn exotic_character_bounds() {
@@ -402,7 +402,7 @@ mod tests {
     fn iterator_tokens_sanity_check() {
         // In reality, one should always prefer to use StrTokens for strings:
         let chars = "hello \n\t world".chars();
-        let mut tokens = IterTokens::<_, StackString<0>>::into_tokens(chars);
+        let mut tokens = IterTokens::<_, ArrayString<0>>::into_tokens(chars);
 
         let loc = tokens.location();
         assert!(tokens.tokens("hello".chars()));


### PR DESCRIPTION
Add parsing of iterators with the `str::parse` function.
Allows re-use of a datatype's `FromStr` implementation and easily changing the temporary buffer type so allocations can be done on the stack (`no_std` compatible) using ex. [`heapless::String`](https://docs.rs/heapless/latest/heapless/struct.String.html) or [`crate::buffered::StackString`](https://github.com/jsdw/yap/compare/master...Easyoakland:yap:buffered-parse?expand=1#diff-6796a3467b922ed638f9106c1d960d495f5b699427175f5f8dba966adb729888R261) instead of naively using a [`std::string::String`](https://doc.rust-lang.org/std/string/struct.String.html) on the heap.