### PR TITLE
Add float parser, generalise one_of/.optional() a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,28 @@
 
 [![API docs](https://docs.rs/yap/badge.svg)](https://docs.rs/yap)
 
-This small, zero-dependency crate helps you to parse input strings, slices and (some) iterators of tokens
-by building on the `Iterator` interface.
+This small, zero-dependency crate helps you to parse input strings and slices by building on the `Iterator`
+interface.
 
 The aim of this crate is to provide the sorts of functions you'd come to expect from a parser
-combinator library, but without immersing you into a world of parser combinators, and forcing you
-to use a novel return type, library-provided errors or parser-combinator based control flow. It hopes
-to sacrifice conciseness in exchange for simplicity.
+combinator library, but without immersing you into a world of parser combinators and forcing you
+to use a novel return type, library-provided errors or parser-combinator based control flow. we
+sacrifice some conciseness in exchange for simplicity.
 
 **Some specific features/goals:**
-- Lots of examples. Every function provided comes with example usage.
+- Great documentation, with examples for almost every function provided.
 - Prioritise simplicity at the cost of verbosity.
-- Be iterator-centric. Where applicable, combinators return iterators, so you can lean on the `Iterator`
-  interface to parse as much or as little as you want from the input, and collect up the output however
-  you wish.
+- Be iterator-centric. Where applicable, combinators return things which implement `Tokens`/`Iterator`.
 - Allow user defined errors to be returned anywhere that it might make sense. Some functions have `_err`
   variants incase you need error information when they don't otherwise hand back errors for simplicity.
 - Location information should always be available, so that you can tell users where something went wrong.
-  see `Tokens::offset`
+  see `Tokens::offset` and `Tokens::location()`.
 - Backtracking by default. Coming from Haskell's Parsec, this feels like the sensible default. It means that
-  if one of the provided parsing functions fails to parse what you asked for, it won't consume any input
-  trying.
-- Expose all of the "low level" functions. You can save and rewind to locations as needed (see `Token::location`),
-  and implement ant of the provided functions using these primitives.
-- Aims to be "fairly quick". Avoids allocations (and allows you to do the same via the iterator-centric interface).
-  If you need "as fast as you can get", there are probably quicker alternatives.
+  if one of the provided parsing functions fails to parse something, it won't consume any input trying.
+- Expose all of the "low level" functions. You can save and rewind to locations as needed (see `Tokens::location`),
+  and implement any of the provided functions using these primitives.
+- Aims to be "fairly quick". Avoids allocations (and allows you to do the same via the iterator-centric interface)
+  almost everywhere. If you need "as fast as you can get", there amay be quicker alternatives.
 
 Have a look at the `Tokens` trait for all of the parsing methods made available, and examples for each.
 

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -296,12 +296,11 @@ fn null(toks: &mut impl Tokens<Item = char>) -> bool {
     toks.tokens("null".chars())
 }
 
-/// Numbers are maybe the most difficult thing to parse. Here, we store the start
-/// location and then skip over tokens as long as they are what we expect, bailing with
-/// `None` if something isn't right. At the end, we gather all of the tokens we skipped
-/// over at once and parse them into a number.
+/// Parse numbers. Here, we store the start location and then skip over tokens as long
+/// as they are what we expect, bailing with `None` if something isn't right. At the end,
+/// we gather all of the tokens we skipped over at once and parse them into a number.
 ///
-/// A better parser could return specific errors depending on where we failed in our parsing.
+/// See `CharTokens::f64` for more correct float parsing.
 fn number(toks: &mut impl Tokens<Item = char>) -> Option<Result<f64, Error>> {
     let start = toks.location();
 

--- a/examples/json.rs
+++ b/examples/json.rs
@@ -294,12 +294,11 @@ fn null(toks: &mut impl Tokens<Item = char>) -> bool {
     toks.tokens("null".chars())
 }
 
-/// Use the [`yap::CharTokens::parse_f64`] utility function to parse
+/// Use the [`yap::chars::parse_f64`] helper function to parse
 /// anything that rust considers a valid float (which is a little more
 /// permissive than the JSON standard, actually).
 fn number(toks: &mut impl Tokens<Item = char>) -> Option<f64> {
-    use yap::CharTokens;
-    toks.parse_f64::<String>()
+    yap::chars::parse_f64::<String>(toks)
 }
 
 fn skip_whitespace(toks: &mut impl Tokens<Item = char>) {

--- a/src/chars.rs
+++ b/src/chars.rs
@@ -48,7 +48,7 @@ pub fn line_ending<T: Tokens<Item = char>>(t: &mut T) -> Option<&'static str> {
 ///
 /// Note that alphabetical characters are not case-sensitive.
 ///
-/// More specifically, all strings that adhere to the following [EBNF] grammar when
+/// More specifically, all strings that adhere to the following EBNF grammar when
 /// lowercased will be consumed, and `true` returned:
 ///
 /// ```txt
@@ -120,12 +120,12 @@ pub fn float<T: Tokens<Item = char>>(t: &mut T) -> bool {
     fn number_with_exp(t: &mut impl Tokens<Item = char>) -> bool {
         t.optional(|t| {
             if !number(t) {
-                return false
+                return false;
             }
             if case_insensitive_eq(t, "e") {
                 sign(t);
                 if !digits(t) {
-                    return false
+                    return false;
                 }
             }
             true
@@ -140,14 +140,14 @@ pub fn float<T: Tokens<Item = char>>(t: &mut T) -> bool {
                 // If there's a point, we're happy as long as d1 or d2
                 // actually contain some digits:
                 d1 || d2
-            } else{
+            } else {
                 // If there's no point then d1 needs to contain digits:
                 d1
             }
         })
     }
     fn digits(t: &mut impl Tokens<Item = char>) -> bool {
-        t.skip_while(|c| c.is_digit(10)) > 0
+        t.skip_while(|c| c.is_ascii_digit()) > 0
     }
 
     sign(t);
@@ -192,14 +192,14 @@ pub fn case_insensitive_eq<T: Tokens<Item = char>>(t: &mut T, s: &str) -> bool {
                         (None, None) => break,
                         _ => {
                             t.set_location(start_loc);
-                            return false
+                            return false;
                         }
                     }
                 }
-            },
+            }
             _ => {
                 t.set_location(start_loc);
-                return false
+                return false;
             }
         }
     }

--- a/src/chars.rs
+++ b/src/chars.rs
@@ -1,275 +1,88 @@
-//! An extension trait providing extra functions when working with `Tokens<Item=char>`.
+//! Helper functions that can be used when working with `Tokens<Item=char>`.
 
 use crate::Tokens;
 
-/// Some extra helper methods specific to parsing token iterators of chars.
-pub trait CharTokens: Tokens<Item = char> {
-    /// If the next tokens are either `\n` (like on linux)  or `\r\n` (like on windows),
-    /// this will consume then and return `Some("\n")` or `Some("\r\n")` respectively.
-    /// If the next tokens are not one of these, then `None` will be returned and nothing
-    /// will be consumed.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use yap::{Tokens, IntoTokens, CharTokens};
-    ///
-    /// let mut toks = "\r\n abc".into_tokens();
-    ///
-    /// assert_eq!(toks.line_ending(), Some("\r\n"));
-    /// assert_eq!(toks.remaining(), " abc");
-    ///
-    /// let mut toks = "\n abc".into_tokens();
-    ///
-    /// assert_eq!(toks.line_ending(), Some("\n"));
-    /// assert_eq!(toks.remaining(), " abc");
-    ///
-    /// let mut toks = "abc".into_tokens();
-    ///
-    /// assert_eq!(toks.line_ending(), None);
-    /// assert_eq!(toks.remaining(), "abc");
-    /// ```
-    fn line_ending(&mut self) -> Option<&'static str> {
-        self.optional(|t| t.token('\n').then_some("\n"))
-            .or_else(|| self.optional(|t| t.tokens("\r\n".chars()).then_some("\r\n")))
-    }
-
-    /// If the next tokens are a valid Rust floating point number, then consume
-    /// them and return them as an [`f64`]. Else, don't consume anything and
-    /// return `None`.
-    ///
-    /// Like [`Tokens::parse`], the generic parameter `Buf` indicates the type of buffer
-    /// that may be used to collect tokens prior to parsing. Implementations like
-    /// [`crate::types::StrTokens`] are optimised to avoid using a buffer in
-    /// many cases.
-    ///
-    /// Use [`CharTokens::float`] if you want to consume the tokens but don't want to parse
-    /// them into an f32 or f64.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use yap::{Tokens, IntoTokens, CharTokens};
-    ///
-    /// let mut toks = "3.14 hi".into_tokens();
-    ///
-    /// let n = toks.parse_f64::<String>().unwrap();
-    /// assert_eq!(toks.remaining(), " hi");
-    /// ```
-    fn parse_f64<Buf>(&mut self) -> Option<f64>
-    where
-        Buf: core::iter::FromIterator<char> + core::ops::Deref<Target = str>,
-    {
-        parse_f::<_, f64, Buf, _>(self)
-    }
-
-    /// If the next tokens are a valid Rust floating point number, then consume
-    /// them and return them as an [`f32`]. Else, don't consume anything and
-    /// return `None`.
-    ///
-    /// Like [`Tokens::parse`], the generic parameter `Buf` indicates the type of buffer
-    /// that may be used to collect tokens prior to parsing. Implementations like
-    /// [`crate::types::StrTokens`] are optimised to avoid using a buffer in
-    /// many cases.
-    ///
-    /// Use [`CharTokens::float`] if you want to consume the tokens but don't want to parse
-    /// them into an f32 or f64.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use yap::{Tokens, IntoTokens, CharTokens};
-    ///
-    /// let mut toks = "3.14 hi".into_tokens();
-    ///
-    /// let n = toks.parse_f32::<String>().unwrap();
-    /// assert_eq!(toks.remaining(), " hi");
-    /// ```
-    fn parse_f32<Buf>(&mut self) -> Option<f32>
-    where
-        Buf: core::iter::FromIterator<char> + core::ops::Deref<Target = str>,
-    {
-        parse_f::<_, f32, Buf, _>(self)
-    }
-
-    /// If the next tokens represent a base10 float that would be successfully parsed with
-    /// `s.parse::<f32>()` or `s.parse::<f64>()`, then they will be consumed and `true` returned.
-    /// Otherwise, `false` is returned and nothing is consumed.
-    ///
-    /// Rust float parsing is quite permissive in general. Strings such as these will be treated
-    /// as valid floats and fully consumed:
-    ///
-    /// * '3.14'
-    /// * '-3.14'
-    /// * '2.5E10', or equivalently, '2.5e10'
-    /// * '2.5E-10'
-    /// * '5.'
-    /// * '.5', or, equivalently, '0.5'
-    /// * 'inf', '-inf', '+infinity', 'NaN'
-    ///
-    /// Note that alphabetical characters are not case-sensitive.
-    ///
-    /// More specifically, all strings that adhere to the following EBNF grammar when
-    /// lowercased will be consumed, and `true` returned:
-    ///
-    /// ```txt
-    /// Float  ::= Sign? ( 'inf' | 'infinity' | 'nan' | Number )
-    /// Number ::= ( Digit+ |
-    ///              Digit+ '.' Digit* |
-    ///              Digit* '.' Digit+ ) Exp?
-    /// Exp    ::= 'e' Sign? Digit+
-    /// Sign   ::= [+-]
-    /// Digit  ::= [0-9]
-    /// ```
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use yap::{Tokens, IntoTokens, CharTokens};
-    /// use core::str::FromStr;
-    ///
-    /// // These will all be fully consumed as valid floats:
-    /// let valid_numbers = [
-    ///     "3.14",
-    ///     "-3.14",
-    ///     "2.5E10",
-    ///     "2.5e-10",
-    ///     "2.5e+10",
-    ///     "+3.123e12",
-    ///     "5.",
-    ///     ".5",
-    ///     "+.5",
-    ///     "0.5",
-    ///     "inf",
-    ///     "NaN",
-    ///     "-infinity",
-    ///     "+infinity",
-    ///     "INFINITY",
-    /// ];
-    ///
-    /// for n in valid_numbers {
-    ///     let mut toks = n.into_tokens();
-    ///
-    ///     assert!(toks.float(), "failed to parse: {}", n);
-    ///     assert_eq!(toks.remaining(), "");
-    ///
-    ///     n.parse::<f64>().expect("Rust can parse the string, too");
-    /// }
-    ///
-    /// // These are all invalid and won't be consumed:
-    /// let invalid_numbers = [
-    ///     // Spaces aren't consumed:
-    ///     " 3.14",
-    ///     // Need a number one side of a decimal point:
-    ///     ".",
-    ///     // The "e" won't be consumed, since nothing follows it:
-    ///     "3e"
-    /// ];
-    ///
-    /// for n in invalid_numbers {
-    ///     let mut toks = n.into_tokens();
-    ///
-    ///     assert!(!toks.float(), "succeeded in parsing: {}", n);
-    ///     assert!(toks.remaining().len() > 0);
-    ///
-    ///     n.parse::<f64>().unwrap_err();
-    /// }
-    /// ```
-    fn float(&mut self) -> bool {
-        fn sign(t: &mut impl Tokens<Item = char>) -> bool {
-            t.token('+') || t.token('-')
-        }
-        fn number_with_exp(t: &mut impl Tokens<Item = char>) -> bool {
-            t.optional(|t| {
-                if !number(t) {
-                    return false;
-                }
-                if t.case_insensitive_eq("e") {
-                    sign(t);
-                    if !digits(t) {
-                        return false;
-                    }
-                }
-                true
-            })
-        }
-        fn number(t: &mut impl Tokens<Item = char>) -> bool {
-            t.optional(|t| {
-                let d1 = digits(t);
-                let point = t.token('.');
-                if point {
-                    let d2 = digits(t);
-                    // If there's a point, we're happy as long as d1 or d2
-                    // actually contain some digits:
-                    d1 || d2
-                } else {
-                    // If there's no point then d1 needs to contain digits:
-                    d1
-                }
-            })
-        }
-        fn digits(t: &mut impl Tokens<Item = char>) -> bool {
-            t.skip_while(|c| c.is_ascii_digit()) > 0
-        }
-
-        sign(self);
-        crate::one_of!(t from self;
-            t.case_insensitive_eq("infinity"),
-            t.case_insensitive_eq("inf"),
-            t.case_insensitive_eq("nan"),
-            number_with_exp(t)
-        )
-    }
-
-    /// If the next tokens are equal (case insensitive) to the string provided,
-    /// this returns `true` and consumes the tokens. Else, it returns `false` and
-    /// doesn't consume anything.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use yap::{Tokens, IntoTokens, CharTokens};
-    ///
-    /// let mut toks = "HeLlO".into_tokens();
-    ///
-    /// assert_eq!(toks.case_insensitive_eq("hello"), true);
-    /// assert_eq!(toks.remaining(), "");
-    ///
-    /// let mut toks = "Howdy".into_tokens();
-    ///
-    /// assert_eq!(toks.case_insensitive_eq("hello"), false);
-    /// assert_eq!(toks.remaining(), "Howdy");
-    /// ```
-    fn case_insensitive_eq(&mut self, s: &str) -> bool {
-        let start_loc = self.location();
-        for c1 in s.chars() {
-            match self.next() {
-                Some(c2) => {
-                    // Lowercase the chars and compare the iters for eqaality:
-                    let mut c1_lower = c1.to_lowercase();
-                    let mut c2_lower = c2.to_lowercase();
-                    loop {
-                        match (c1_lower.next(), c2_lower.next()) {
-                            (Some(a), Some(b)) if a == b => continue,
-                            (None, None) => break,
-                            _ => {
-                                self.set_location(start_loc);
-                                return false;
-                            }
-                        }
-                    }
-                }
-                _ => {
-                    self.set_location(start_loc);
-                    return false;
-                }
-            }
-        }
-        true
-    }
+/// If the next tokens are either `\n` (like on linux)  or `\r\n` (like on windows),
+/// this will consume then and return `Some("\n")` or `Some("\r\n")` respectively.
+/// If the next tokens are not one of these, then `None` will be returned and nothing
+/// will be consumed.
+///
+/// # Example
+///
+/// ```
+/// use yap::{Tokens, IntoTokens, chars};
+///
+/// let mut toks = "\r\n abc".into_tokens();
+///
+/// assert_eq!(chars::line_ending(&mut toks), Some("\r\n"));
+/// assert_eq!(toks.remaining(), " abc");
+///
+/// let mut toks = "\n abc".into_tokens();
+///
+/// assert_eq!(chars::line_ending(&mut toks), Some("\n"));
+/// assert_eq!(toks.remaining(), " abc");
+///
+/// let mut toks = "abc".into_tokens();
+///
+/// assert_eq!(chars::line_ending(&mut toks), None);
+/// assert_eq!(toks.remaining(), "abc");
+/// ```
+pub fn line_ending(toks: &mut impl Tokens<Item = char>) -> Option<&'static str> {
+    toks.optional(|t| t.token('\n').then_some("\n"))
+        .or_else(|| toks.optional(|t| t.tokens("\r\n".chars()).then_some("\r\n")))
 }
 
-impl<T: Tokens<Item = char>> CharTokens for T {}
+/// If the next tokens are a valid Rust floating point number (see [`float`]
+/// for more details), then consume them and return them as an [`f32`]. Else,
+/// don't consume anything and return `None`.
+///
+/// Like [`Tokens::parse`], the generic parameter `Buf` indicates the type of buffer
+/// that may be used to collect tokens prior to parsing. Implementations like
+/// [`crate::types::StrTokens`] are optimised to avoid using a buffer in
+/// many cases.
+///
+/// # Example
+///
+/// ```
+/// use yap::{Tokens, IntoTokens, chars};
+///
+/// let mut toks = "3.14 hi".into_tokens();
+///
+/// let n = chars::parse_f64::<String>(&mut toks).unwrap();
+/// assert_eq!(toks.remaining(), " hi");
+/// ```
+pub fn parse_f64<Buf>(toks: &mut impl Tokens<Item = char>) -> Option<f64>
+where
+    Buf: core::iter::FromIterator<char> + core::ops::Deref<Target = str>,
+{
+    parse_f::<_, f64, Buf, _>(toks)
+}
+
+/// If the next tokens are a valid Rust floating point number (see [`float`]
+/// for more details), then consume them and return them as an [`f32`]. Else,
+/// don't consume anything and return `None`.
+///
+/// Like [`Tokens::parse`], the generic parameter `Buf` indicates the type of buffer
+/// that may be used to collect tokens prior to parsing. Implementations like
+/// [`crate::types::StrTokens`] are optimised to avoid using a buffer in
+/// many cases.
+///
+/// # Example
+///
+/// ```
+/// use yap::{Tokens, IntoTokens, chars};
+///
+/// let mut toks = "3.14 hi".into_tokens();
+///
+/// let n = chars::parse_f32::<String>(&mut toks).unwrap();
+/// assert_eq!(toks.remaining(), " hi");
+/// ```
+pub fn parse_f32<Buf>(toks: &mut impl Tokens<Item = char>) -> Option<f32>
+where
+    Buf: core::iter::FromIterator<char> + core::ops::Deref<Target = str>,
+{
+    parse_f::<_, f32, Buf, _>(toks)
+}
 
 // Parse an f32 or f64 from the input, returning None if the input
 // did not contain a valid rust style float. This is expected to be
@@ -283,7 +96,7 @@ where
     B: core::iter::FromIterator<char> + core::ops::Deref<Target = str>,
 {
     let l1 = t.location();
-    if !CharTokens::float(t) {
+    if !float(t) {
         return None;
     }
     let l2 = t.location();
@@ -294,4 +107,180 @@ where
         .expect("valid float expected");
 
     Some(f)
+}
+
+/// If the next tokens represent a base10 float that would be successfully parsed with
+/// `s.parse::<f32>()` or `s.parse::<f64>()`, then they will be consumed and `true` returned.
+/// Otherwise, `false` is returned and nothing is consumed.
+///
+/// Rust float parsing is quite permissive in general. Strings such as these will be treated
+/// as valid floats and fully consumed:
+///
+/// * '3.14'
+/// * '-3.14'
+/// * '2.5E10', or equivalently, '2.5e10'
+/// * '2.5E-10'
+/// * '5.'
+/// * '.5', or, equivalently, '0.5'
+/// * 'inf', '-inf', '+infinity', 'NaN'
+///
+/// Note that alphabetical characters are not case-sensitive.
+///
+/// More specifically, all strings that adhere to the following EBNF grammar when
+/// lowercased will be consumed, and `true` returned:
+///
+/// ```txt
+/// Float  ::= Sign? ( 'inf' | 'infinity' | 'nan' | Number )
+/// Number ::= ( Digit+ |
+///              Digit+ '.' Digit* |
+///              Digit* '.' Digit+ ) Exp?
+/// Exp    ::= 'e' Sign? Digit+
+/// Sign   ::= [+-]
+/// Digit  ::= [0-9]
+/// ```
+///
+/// # Example
+///
+/// ```
+/// use yap::{Tokens, IntoTokens, chars};
+/// use core::str::FromStr;
+///
+/// // These will all be fully consumed as valid floats:
+/// let valid_numbers = [
+///     "3.14",
+///     "-3.14",
+///     "2.5E10",
+///     "2.5e-10",
+///     "2.5e+10",
+///     "+3.123e12",
+///     "5.",
+///     ".5",
+///     "+.5",
+///     "0.5",
+///     "inf",
+///     "NaN",
+///     "-infinity",
+///     "+infinity",
+///     "INFINITY",
+/// ];
+///
+/// for n in valid_numbers {
+///     let mut toks = n.into_tokens();
+///
+///     assert!(chars::float(&mut toks), "failed to parse: {}", n);
+///     assert_eq!(toks.remaining(), "");
+///
+///     n.parse::<f64>().expect("Rust can parse the string, too");
+/// }
+///
+/// // These are all invalid and won't be consumed:
+/// let invalid_numbers = [
+///     // Spaces aren't consumed:
+///     " 3.14",
+///     // Need a number one side of a decimal point:
+///     ".",
+///     // The "e" won't be consumed, since nothing follows it:
+///     "3e"
+/// ];
+///
+/// for n in invalid_numbers {
+///     let mut toks = n.into_tokens();
+///
+///     assert!(!chars::float(&mut toks), "succeeded in parsing: {}", n);
+///     assert!(toks.remaining().len() > 0);
+///
+///     n.parse::<f64>().unwrap_err();
+/// }
+/// ```
+pub fn float(toks: &mut impl Tokens<Item = char>) -> bool {
+    fn sign(t: &mut impl Tokens<Item = char>) -> bool {
+        t.token('+') || t.token('-')
+    }
+    fn number_with_exp(t: &mut impl Tokens<Item = char>) -> bool {
+        t.optional(|t| {
+            if !number(t) {
+                return false;
+            }
+            if case_insensitive_eq(t, "e") {
+                sign(t);
+                if !digits(t) {
+                    return false;
+                }
+            }
+            true
+        })
+    }
+    fn number(t: &mut impl Tokens<Item = char>) -> bool {
+        t.optional(|t| {
+            let d1 = digits(t);
+            let point = t.token('.');
+            if point {
+                let d2 = digits(t);
+                // If there's a point, we're happy as long as d1 or d2
+                // actually contain some digits:
+                d1 || d2
+            } else {
+                // If there's no point then d1 needs to contain digits:
+                d1
+            }
+        })
+    }
+    fn digits(t: &mut impl Tokens<Item = char>) -> bool {
+        t.skip_while(|c| c.is_ascii_digit()) > 0
+    }
+
+    sign(toks);
+    crate::one_of!(t from toks;
+        case_insensitive_eq(t, "infinity"),
+        case_insensitive_eq(t, "inf"),
+        case_insensitive_eq(t, "nan"),
+        number_with_exp(t)
+    )
+}
+
+/// If the next tokens are equal (case insensitive) to the string provided,
+/// this returns `true` and consumes the tokens. Else, it returns `false` and
+/// doesn't consume anything.
+///
+/// # Example
+///
+/// ```
+/// use yap::{Tokens, IntoTokens, chars};
+///
+/// let mut toks = "HeLlO".into_tokens();
+///
+/// assert_eq!(chars::case_insensitive_eq(&mut toks, "hello"), true);
+/// assert_eq!(toks.remaining(), "");
+///
+/// let mut toks = "Howdy".into_tokens();
+///
+/// assert_eq!(chars::case_insensitive_eq(&mut toks, "hello"), false);
+/// assert_eq!(toks.remaining(), "Howdy");
+/// ```
+pub fn case_insensitive_eq(toks: &mut impl Tokens<Item = char>, s: &str) -> bool {
+    let start_loc = toks.location();
+    for c1 in s.chars() {
+        match toks.next() {
+            Some(c2) => {
+                // Lowercase the chars and compare the iters for eqaality:
+                let mut c1_lower = c1.to_lowercase();
+                let mut c2_lower = c2.to_lowercase();
+                loop {
+                    match (c1_lower.next(), c2_lower.next()) {
+                        (Some(a), Some(b)) if a == b => continue,
+                        (None, None) => break,
+                        _ => {
+                            toks.set_location(start_loc);
+                            return false;
+                        }
+                    }
+                }
+            }
+            _ => {
+                toks.set_location(start_loc);
+                return false;
+            }
+        }
+    }
+    true
 }

--- a/src/chars.rs
+++ b/src/chars.rs
@@ -53,7 +53,7 @@ pub trait CharTokens: Tokens<Item = char> {
     /// ```
     fn parse_f64<B>(&mut self) -> Option<f64>
     where
-        B: std::iter::FromIterator<char> + std::ops::Deref<Target = str>,
+        B: core::iter::FromIterator<char> + core::ops::Deref<Target = str>,
     {
         parse_f::<_, f64, B, _>(self)
     }
@@ -77,7 +77,7 @@ pub trait CharTokens: Tokens<Item = char> {
     /// ```
     fn parse_f32<B>(&mut self) -> Option<f32>
     where
-        B: std::iter::FromIterator<char> + std::ops::Deref<Target = str>,
+        B: core::iter::FromIterator<char> + core::ops::Deref<Target = str>,
     {
         parse_f::<_, f32, B, _>(self)
     }
@@ -115,7 +115,7 @@ pub trait CharTokens: Tokens<Item = char> {
     ///
     /// ```
     /// use yap::{Tokens, IntoTokens, CharTokens};
-    /// use std::str::FromStr;
+    /// use core::str::FromStr;
     ///
     /// // These will all be fully consumed as valid floats:
     /// let valid_numbers = [
@@ -263,9 +263,9 @@ impl<T: Tokens<Item = char>> CharTokens for T {}
 fn parse_f<T: Tokens<Item = char>, F, B, E>(t: &mut T) -> Option<F>
 where
     T: Tokens<Item = char>,
-    F: std::str::FromStr<Err = E>,
-    E: std::fmt::Debug,
-    B: std::iter::FromIterator<char> + std::ops::Deref<Target = str>,
+    F: core::str::FromStr<Err = E>,
+    E: core::fmt::Debug,
+    B: core::iter::FromIterator<char> + core::ops::Deref<Target = str>,
 {
     let l1 = t.location();
     if !CharTokens::float(t) {

--- a/src/chars.rs
+++ b/src/chars.rs
@@ -1,4 +1,4 @@
-//! Helper functions for working with `Tokens<Item=char>`.
+//! An extension trait providing extra functions when working with `Tokens<Item=char>`.
 
 use crate::Tokens;
 

--- a/src/chars.rs
+++ b/src/chars.rs
@@ -2,206 +2,281 @@
 
 use crate::Tokens;
 
-/// If the next tokens are either `\n` (like on linux)  or `\r\n` (like on windows),
-/// this will consume then and return `Some("\n")` or `Some("\r\n")` respectively.
-/// If the next tokens are not one of these, then `None` will be returned and nothing
-/// will be consumed.
-///
-/// # Example
-///
-/// ```
-/// use yap::{Tokens, IntoTokens, chars};
-///
-/// let mut toks = "\r\n abc".into_tokens();
-///
-/// assert_eq!(chars::line_ending(&mut toks), Some("\r\n"));
-/// assert_eq!(toks.remaining(), " abc");
-///
-/// let mut toks = "\n abc".into_tokens();
-///
-/// assert_eq!(chars::line_ending(&mut toks), Some("\n"));
-/// assert_eq!(toks.remaining(), " abc");
-///
-/// let mut toks = "abc".into_tokens();
-///
-/// assert_eq!(chars::line_ending(&mut toks), None);
-/// assert_eq!(toks.remaining(), "abc");
-/// ```
-pub fn line_ending<T: Tokens<Item = char>>(t: &mut T) -> Option<&'static str> {
-    t.optional(|t| t.token('\n').then_some("\n"))
-        .or_else(|| t.optional(|t| t.tokens("\r\n".chars()).then_some("\r\n")))
-}
-
-/// If the next tokens represent a base10 float that would be successfully parsed with
-/// `s.parse::<f32>()` or `s.parse::<f64>()`, then they will be consumed and `true` returned.
-/// Otherwise, `false` is returned and nothing is consumed.
-///
-/// Strings such as these will be consumed:
-///
-/// * '3.14'
-/// * '-3.14'
-/// * '2.5E10', or equivalently, '2.5e10'
-/// * '2.5E-10'
-/// * '5.'
-/// * '.5', or, equivalently, '0.5'
-/// * 'inf', '-inf', '+infinity', 'NaN'
-///
-/// Note that alphabetical characters are not case-sensitive.
-///
-/// More specifically, all strings that adhere to the following EBNF grammar when
-/// lowercased will be consumed, and `true` returned:
-///
-/// ```txt
-/// Float  ::= Sign? ( 'inf' | 'infinity' | 'nan' | Number )
-/// Number ::= ( Digit+ |
-///              Digit+ '.' Digit* |
-///              Digit* '.' Digit+ ) Exp?
-/// Exp    ::= 'e' Sign? Digit+
-/// Sign   ::= [+-]
-/// Digit  ::= [0-9]
-/// ```
-///
-/// # Example
-///
-/// ```
-/// use yap::{Tokens, IntoTokens, chars::float};
-/// use std::str::FromStr;
-///
-/// // These will all be fully consumed as valid floats:
-/// let valid_numbers = [
-///     "3.14",
-///     "-3.14",
-///     "2.5E10",
-///     "2.5e10",
-///     "+3.123e12",
-///     "5.",
-///     ".5",
-///     "+.5",
-///     "0.5",
-///     "inf",
-///     "NaN",
-///     "-infinity",
-///     "+infinity",
-///     "INFINITY",
-/// ];
-///
-/// for n in valid_numbers {
-///     let mut toks = n.into_tokens();
-///
-///     assert!(float(&mut toks), "failed to parse: {}", n);
-///     assert_eq!(toks.remaining(), "");
-///
-///     n.parse::<f64>().expect("Rust can parse the string, too");
-/// }
-///
-/// // These are all invalid and won't be consumed:
-/// let invalid_numbers = [
-///     // Spaces aren't consumed:
-///     " 3.14",
-///     // Need a number one side of a decimal point:
-///     ".",
-///     // The "e" won't be consumed, since nothing follows it:
-///     "3e"
-/// ];
-///
-/// for n in invalid_numbers {
-///     let mut toks = n.into_tokens();
-///
-///     assert!(!float(&mut toks), "succeeded in parsing: {}", n);
-///     assert!(toks.remaining().len() > 0);
-///
-///     n.parse::<f64>().unwrap_err();
-/// }
-/// ```
-pub fn float<T: Tokens<Item = char>>(t: &mut T) -> bool {
-    fn sign(t: &mut impl Tokens<Item = char>) -> bool {
-        t.token('+') || t.token('-')
+/// Some extra helper methods specific to parsing token iterators of chars.
+pub trait CharTokens: Tokens<Item = char> {
+    /// If the next tokens are either `\n` (like on linux)  or `\r\n` (like on windows),
+    /// this will consume then and return `Some("\n")` or `Some("\r\n")` respectively.
+    /// If the next tokens are not one of these, then `None` will be returned and nothing
+    /// will be consumed.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use yap::{Tokens, IntoTokens, CharTokens};
+    ///
+    /// let mut toks = "\r\n abc".into_tokens();
+    ///
+    /// assert_eq!(toks.line_ending(), Some("\r\n"));
+    /// assert_eq!(toks.remaining(), " abc");
+    ///
+    /// let mut toks = "\n abc".into_tokens();
+    ///
+    /// assert_eq!(toks.line_ending(), Some("\n"));
+    /// assert_eq!(toks.remaining(), " abc");
+    ///
+    /// let mut toks = "abc".into_tokens();
+    ///
+    /// assert_eq!(toks.line_ending(), None);
+    /// assert_eq!(toks.remaining(), "abc");
+    /// ```
+    fn line_ending(&mut self) -> Option<&'static str> {
+        self.optional(|t| t.token('\n').then_some("\n"))
+            .or_else(|| self.optional(|t| t.tokens("\r\n".chars()).then_some("\r\n")))
     }
-    fn number_with_exp(t: &mut impl Tokens<Item = char>) -> bool {
-        t.optional(|t| {
-            if !number(t) {
-                return false;
-            }
-            if case_insensitive_eq(t, "e") {
-                sign(t);
-                if !digits(t) {
+
+    /// If the next tokens are a valid floating point number, then consume
+    /// them and return them as an [`f64`]. Else, don't consume anything and
+    /// return `None`.
+    ///
+    /// Use [`CharTokens::float`] if you want to consume the tokens but don't want to parse
+    /// them into an f32 or f64.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use yap::{Tokens, IntoTokens, CharTokens};
+    ///
+    /// let mut toks = "3.14 hi".into_tokens();
+    ///
+    /// let n = toks.parse_f64::<String>().unwrap();
+    /// assert_eq!(toks.remaining(), " hi");
+    /// ```
+    fn parse_f64<B>(&mut self) -> Option<f64>
+    where
+        B: std::iter::FromIterator<char> + std::ops::Deref<Target = str>,
+    {
+        parse_f::<_, f64, B, _>(self)
+    }
+
+    /// If the next tokens are a valid floating point number, then consume
+    /// them and return them as an [`f32`]. Else, don't consume anything and
+    /// return `None`.
+    ///
+    /// Use [`CharTokens::float`] if you want to consume the tokens but don't want to parse
+    /// them into an f32 or f64.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use yap::{Tokens, IntoTokens, CharTokens};
+    ///
+    /// let mut toks = "3.14 hi".into_tokens();
+    ///
+    /// let n = toks.parse_f32::<String>().unwrap();
+    /// assert_eq!(toks.remaining(), " hi");
+    /// ```
+    fn parse_f32<B>(&mut self) -> Option<f32>
+    where
+        B: std::iter::FromIterator<char> + std::ops::Deref<Target = str>,
+    {
+        parse_f::<_, f32, B, _>(self)
+    }
+
+    /// If the next tokens represent a base10 float that would be successfully parsed with
+    /// `s.parse::<f32>()` or `s.parse::<f64>()`, then they will be consumed and `true` returned.
+    /// Otherwise, `false` is returned and nothing is consumed.
+    ///
+    /// Strings such as these will be consumed:
+    ///
+    /// * '3.14'
+    /// * '-3.14'
+    /// * '2.5E10', or equivalently, '2.5e10'
+    /// * '2.5E-10'
+    /// * '5.'
+    /// * '.5', or, equivalently, '0.5'
+    /// * 'inf', '-inf', '+infinity', 'NaN'
+    ///
+    /// Note that alphabetical characters are not case-sensitive.
+    ///
+    /// More specifically, all strings that adhere to the following EBNF grammar when
+    /// lowercased will be consumed, and `true` returned:
+    ///
+    /// ```txt
+    /// Float  ::= Sign? ( 'inf' | 'infinity' | 'nan' | Number )
+    /// Number ::= ( Digit+ |
+    ///              Digit+ '.' Digit* |
+    ///              Digit* '.' Digit+ ) Exp?
+    /// Exp    ::= 'e' Sign? Digit+
+    /// Sign   ::= [+-]
+    /// Digit  ::= [0-9]
+    /// ```
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use yap::{Tokens, IntoTokens, CharTokens};
+    /// use std::str::FromStr;
+    ///
+    /// // These will all be fully consumed as valid floats:
+    /// let valid_numbers = [
+    ///     "3.14",
+    ///     "-3.14",
+    ///     "2.5E10",
+    ///     "2.5e10",
+    ///     "+3.123e12",
+    ///     "5.",
+    ///     ".5",
+    ///     "+.5",
+    ///     "0.5",
+    ///     "inf",
+    ///     "NaN",
+    ///     "-infinity",
+    ///     "+infinity",
+    ///     "INFINITY",
+    /// ];
+    ///
+    /// for n in valid_numbers {
+    ///     let mut toks = n.into_tokens();
+    ///
+    ///     assert!(toks.float(), "failed to parse: {}", n);
+    ///     assert_eq!(toks.remaining(), "");
+    ///
+    ///     n.parse::<f64>().expect("Rust can parse the string, too");
+    /// }
+    ///
+    /// // These are all invalid and won't be consumed:
+    /// let invalid_numbers = [
+    ///     // Spaces aren't consumed:
+    ///     " 3.14",
+    ///     // Need a number one side of a decimal point:
+    ///     ".",
+    ///     // The "e" won't be consumed, since nothing follows it:
+    ///     "3e"
+    /// ];
+    ///
+    /// for n in invalid_numbers {
+    ///     let mut toks = n.into_tokens();
+    ///
+    ///     assert!(!toks.float(), "succeeded in parsing: {}", n);
+    ///     assert!(toks.remaining().len() > 0);
+    ///
+    ///     n.parse::<f64>().unwrap_err();
+    /// }
+    /// ```
+    fn float(&mut self) -> bool {
+        fn sign(t: &mut impl Tokens<Item = char>) -> bool {
+            t.token('+') || t.token('-')
+        }
+        fn number_with_exp(t: &mut impl Tokens<Item = char>) -> bool {
+            t.optional(|t| {
+                if !number(t) {
                     return false;
                 }
-            }
-            true
-        })
-    }
-    fn number(t: &mut impl Tokens<Item = char>) -> bool {
-        t.optional(|t| {
-            let d1 = digits(t);
-            let point = t.token('.');
-            if point {
-                let d2 = digits(t);
-                // If there's a point, we're happy as long as d1 or d2
-                // actually contain some digits:
-                d1 || d2
-            } else {
-                // If there's no point then d1 needs to contain digits:
-                d1
-            }
-        })
-    }
-    fn digits(t: &mut impl Tokens<Item = char>) -> bool {
-        t.skip_while(|c| c.is_ascii_digit()) > 0
+                if t.case_insensitive_eq("e") {
+                    sign(t);
+                    if !digits(t) {
+                        return false;
+                    }
+                }
+                true
+            })
+        }
+        fn number(t: &mut impl Tokens<Item = char>) -> bool {
+            t.optional(|t| {
+                let d1 = digits(t);
+                let point = t.token('.');
+                if point {
+                    let d2 = digits(t);
+                    // If there's a point, we're happy as long as d1 or d2
+                    // actually contain some digits:
+                    d1 || d2
+                } else {
+                    // If there's no point then d1 needs to contain digits:
+                    d1
+                }
+            })
+        }
+        fn digits(t: &mut impl Tokens<Item = char>) -> bool {
+            t.skip_while(|c| c.is_ascii_digit()) > 0
+        }
+
+        sign(self);
+        crate::one_of!(t from self;
+            t.case_insensitive_eq("infinity"),
+            t.case_insensitive_eq("inf"),
+            t.case_insensitive_eq("nan"),
+            number_with_exp(t)
+        )
     }
 
-    sign(t);
-    crate::one_of!(t;
-        case_insensitive_eq(t, "infinity"),
-        case_insensitive_eq(t, "inf"),
-        case_insensitive_eq(t, "nan"),
-        number_with_exp(t)
-    )
-}
-
-/// If the next tokens are equal (case insensitive) to the string provided,
-/// this returns `true` and consumes the tokens. Else, it returns `false` and
-/// doesn't consume anything.
-///
-/// # Example
-///
-/// ```
-/// use yap::{Tokens, IntoTokens, chars};
-///
-/// let mut toks = "HeLlO".into_tokens();
-///
-/// assert_eq!(chars::case_insensitive_eq(&mut toks, "hello"), true);
-/// assert_eq!(toks.remaining(), "");
-///
-/// let mut toks = "Howdy".into_tokens();
-///
-/// assert_eq!(chars::case_insensitive_eq(&mut toks, "hello"), false);
-/// assert_eq!(toks.remaining(), "Howdy");
-/// ```
-pub fn case_insensitive_eq<T: Tokens<Item = char>>(t: &mut T, s: &str) -> bool {
-    let start_loc = t.location();
-    for c1 in s.chars() {
-        match t.next() {
-            Some(c2) => {
-                // Lowercase the chars and compare the iters for eqaality:
-                let mut c1_lower = c1.to_lowercase();
-                let mut c2_lower = c2.to_lowercase();
-                loop {
-                    match (c1_lower.next(), c2_lower.next()) {
-                        (Some(a), Some(b)) if a == b => continue,
-                        (None, None) => break,
-                        _ => {
-                            t.set_location(start_loc);
-                            return false;
+    /// If the next tokens are equal (case insensitive) to the string provided,
+    /// this returns `true` and consumes the tokens. Else, it returns `false` and
+    /// doesn't consume anything.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use yap::{Tokens, IntoTokens, CharTokens};
+    ///
+    /// let mut toks = "HeLlO".into_tokens();
+    ///
+    /// assert_eq!(toks.case_insensitive_eq("hello"), true);
+    /// assert_eq!(toks.remaining(), "");
+    ///
+    /// let mut toks = "Howdy".into_tokens();
+    ///
+    /// assert_eq!(toks.case_insensitive_eq("hello"), false);
+    /// assert_eq!(toks.remaining(), "Howdy");
+    /// ```
+    fn case_insensitive_eq(&mut self, s: &str) -> bool {
+        let start_loc = self.location();
+        for c1 in s.chars() {
+            match self.next() {
+                Some(c2) => {
+                    // Lowercase the chars and compare the iters for eqaality:
+                    let mut c1_lower = c1.to_lowercase();
+                    let mut c2_lower = c2.to_lowercase();
+                    loop {
+                        match (c1_lower.next(), c2_lower.next()) {
+                            (Some(a), Some(b)) if a == b => continue,
+                            (None, None) => break,
+                            _ => {
+                                self.set_location(start_loc);
+                                return false;
+                            }
                         }
                     }
                 }
-            }
-            _ => {
-                t.set_location(start_loc);
-                return false;
+                _ => {
+                    self.set_location(start_loc);
+                    return false;
+                }
             }
         }
+        true
     }
-    true
+}
+
+impl<T: Tokens<Item = char>> CharTokens for T {}
+
+#[inline(always)]
+fn parse_f<T: Tokens<Item = char>, F, B, E>(t: &mut T) -> Option<F>
+where
+    T: Tokens<Item = char>,
+    F: std::str::FromStr<Err = E>,
+    E: std::fmt::Debug,
+    B: std::iter::FromIterator<char> + std::ops::Deref<Target = str>,
+{
+    let l1 = t.location();
+    if !CharTokens::float(t) {
+        return None;
+    }
+    let l2 = t.location();
+
+    let f = t
+        .slice(l1, l2)
+        .parse::<F, B>()
+        .expect("valid float expected");
+
+    Some(f)
 }

--- a/src/chars.rs
+++ b/src/chars.rs
@@ -38,6 +38,11 @@ pub trait CharTokens: Tokens<Item = char> {
     /// them and return them as an [`f64`]. Else, don't consume anything and
     /// return `None`.
     ///
+    /// Like [`Tokens::parse`], the generic parameter indicates the type of buffer that
+    /// may be used to collect tokens prior to parsing. Implementations like
+    /// [`crate::types::StrTokens`] have optimisations to avoid needing this buffer in
+    /// many cases.
+    ///
     /// Use [`CharTokens::float`] if you want to consume the tokens but don't want to parse
     /// them into an f32 or f64.
     ///
@@ -61,6 +66,11 @@ pub trait CharTokens: Tokens<Item = char> {
     /// If the next tokens are a valid floating point number, then consume
     /// them and return them as an [`f32`]. Else, don't consume anything and
     /// return `None`.
+    ///
+    /// Like [`Tokens::parse`], the generic parameter indicates the type of buffer that
+    /// may be used to collect tokens prior to parsing. Implementations like
+    /// [`crate::types::StrTokens`] have optimisations to avoid needing this buffer in
+    /// many cases.
     ///
     /// Use [`CharTokens::float`] if you want to consume the tokens but don't want to parse
     /// them into an f32 or f64.

--- a/src/chars.rs
+++ b/src/chars.rs
@@ -2,9 +2,10 @@
 
 use crate::Tokens;
 
-/// Parses a line ending of either `\n` (like on linux)  or `\r\n` (like on windows).
-/// Returns a static string equal to the line ending parsed, or `None` if no line
-/// ending is seen at this location.
+/// If the next tokens are either `\n` (like on linux)  or `\r\n` (like on windows),
+/// this will consume then and return `Some("\n")` or `Some("\r\n")` respectively.
+/// If the next tokens are not one of these, then `None` will be returned and nothing
+/// will be consumed.
 ///
 /// # Example
 ///
@@ -20,8 +21,187 @@ use crate::Tokens;
 ///
 /// assert_eq!(chars::line_ending(&mut toks), Some("\n"));
 /// assert_eq!(toks.remaining(), " abc");
+///
+/// let mut toks = "abc".into_tokens();
+///
+/// assert_eq!(chars::line_ending(&mut toks), None);
+/// assert_eq!(toks.remaining(), "abc");
 /// ```
 pub fn line_ending<T: Tokens<Item = char>>(t: &mut T) -> Option<&'static str> {
     t.optional(|t| t.token('\n').then_some("\n"))
         .or_else(|| t.optional(|t| t.tokens("\r\n".chars()).then_some("\r\n")))
+}
+
+/// If the next tokens represent a base10 float that would be successfully parsed with
+/// `s.parse::<f32>()` or `s.parse::<f64>()`, then they will be consumed and `true` returned.
+/// Otherwise, `false` is returned and nothing is consumed.
+///
+/// Strings such as these will be consumed:
+///
+/// * '3.14'
+/// * '-3.14'
+/// * '2.5E10', or equivalently, '2.5e10'
+/// * '2.5E-10'
+/// * '5.'
+/// * '.5', or, equivalently, '0.5'
+/// * 'inf', '-inf', '+infinity', 'NaN'
+///
+/// Note that alphabetical characters are not case-sensitive.
+///
+/// More specifically, all strings that adhere to the following [EBNF] grammar when
+/// lowercased will be consumed, and `true` returned:
+///
+/// ```txt
+/// Float  ::= Sign? ( 'inf' | 'infinity' | 'nan' | Number )
+/// Number ::= ( Digit+ |
+///              Digit+ '.' Digit* |
+///              Digit* '.' Digit+ ) Exp?
+/// Exp    ::= 'e' Sign? Digit+
+/// Sign   ::= [+-]
+/// Digit  ::= [0-9]
+/// ```
+///
+/// # Example
+///
+/// ```
+/// use yap::{Tokens, IntoTokens, chars::float};
+/// use std::str::FromStr;
+///
+/// // These will all be fully consumed as valid floats:
+/// let valid_numbers = [
+///     "3.14",
+///     "-3.14",
+///     "2.5E10",
+///     "2.5e10",
+///     "+3.123e12",
+///     "5.",
+///     ".5",
+///     "+.5",
+///     "0.5",
+///     "inf",
+///     "NaN",
+///     "-infinity",
+///     "+infinity",
+///     "INFINITY",
+/// ];
+///
+/// for n in valid_numbers {
+///     let mut toks = n.into_tokens();
+///
+///     assert!(float(&mut toks), "failed to parse: {}", n);
+///     assert_eq!(toks.remaining(), "");
+///
+///     n.parse::<f64>().expect("Rust can parse the string, too");
+/// }
+///
+/// // These are all invalid and won't be consumed:
+/// let invalid_numbers = [
+///     // Spaces aren't consumed:
+///     " 3.14",
+///     // Need a number one side of a decimal point:
+///     ".",
+///     // The "e" won't be consumed, since nothing follows it:
+///     "3e"
+/// ];
+///
+/// for n in invalid_numbers {
+///     let mut toks = n.into_tokens();
+///
+///     assert!(!float(&mut toks), "succeeded in parsing: {}", n);
+///     assert!(toks.remaining().len() > 0);
+///
+///     n.parse::<f64>().unwrap_err();
+/// }
+/// ```
+pub fn float<T: Tokens<Item = char>>(t: &mut T) -> bool {
+    fn sign(t: &mut impl Tokens<Item = char>) -> bool {
+        t.token('+') || t.token('-')
+    }
+    fn number_with_exp(t: &mut impl Tokens<Item = char>) -> bool {
+        t.optional(|t| {
+            if !number(t) {
+                return false
+            }
+            if case_insensitive_eq(t, "e") {
+                sign(t);
+                if !digits(t) {
+                    return false
+                }
+            }
+            true
+        })
+    }
+    fn number(t: &mut impl Tokens<Item = char>) -> bool {
+        t.optional(|t| {
+            let d1 = digits(t);
+            let point = t.token('.');
+            if point {
+                let d2 = digits(t);
+                // If there's a point, we're happy as long as d1 or d2
+                // actually contain some digits:
+                d1 || d2
+            } else{
+                // If there's no point then d1 needs to contain digits:
+                d1
+            }
+        })
+    }
+    fn digits(t: &mut impl Tokens<Item = char>) -> bool {
+        t.skip_while(|c| c.is_digit(10)) > 0
+    }
+
+    sign(t);
+    crate::one_of!(t;
+        case_insensitive_eq(t, "infinity"),
+        case_insensitive_eq(t, "inf"),
+        case_insensitive_eq(t, "nan"),
+        number_with_exp(t)
+    )
+}
+
+/// If the next tokens are equal (case insensitive) to the string provided,
+/// this returns `true` and consumes the tokens. Else, it returns `false` and
+/// doesn't consume anything.
+///
+/// # Example
+///
+/// ```
+/// use yap::{Tokens, IntoTokens, chars};
+///
+/// let mut toks = "HeLlO".into_tokens();
+///
+/// assert_eq!(chars::case_insensitive_eq(&mut toks, "hello"), true);
+/// assert_eq!(toks.remaining(), "");
+///
+/// let mut toks = "Howdy".into_tokens();
+///
+/// assert_eq!(chars::case_insensitive_eq(&mut toks, "hello"), false);
+/// assert_eq!(toks.remaining(), "Howdy");
+/// ```
+pub fn case_insensitive_eq<T: Tokens<Item = char>>(t: &mut T, s: &str) -> bool {
+    let start_loc = t.location();
+    for c1 in s.chars() {
+        match t.next() {
+            Some(c2) => {
+                // Lowercase the chars and compare the iters for eqaality:
+                let mut c1_lower = c1.to_lowercase();
+                let mut c2_lower = c2.to_lowercase();
+                loop {
+                    match (c1_lower.next(), c2_lower.next()) {
+                        (Some(a), Some(b)) if a == b => continue,
+                        (None, None) => break,
+                        _ => {
+                            t.set_location(start_loc);
+                            return false
+                        }
+                    }
+                }
+            },
+            _ => {
+                t.set_location(start_loc);
+                return false
+            }
+        }
+    }
+    true
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,12 +111,11 @@ assert_eq!(remaining, ",foobar");
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-mod chars;
 mod tokens;
 
 #[doc(hidden)]
 pub mod one_of;
 
+pub mod chars;
 pub mod types;
-pub use chars::CharTokens;
 pub use tokens::{IntoTokens, TokenLocation, Tokens};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,27 +3,24 @@ This small, zero-dependency crate helps you to parse input strings and slices by
 interface.
 
 The aim of this crate is to provide the sorts of functions you'd come to expect from a parser
-combinator library, but without immersing you into a world of parser combinators, and forcing you
-to use a novel return type, library-provided errors or parser-combinator based control flow. It hopes
-to sacrifice conciseness in exchange for simplicity.
+combinator library, but without immersing you into a world of parser combinators and forcing you
+to use a novel return type, library-provided errors or parser-combinator based control flow. we
+sacrifice some conciseness in exchange for simplicity.
 
 **Some specific features/goals:**
-- Lots of examples. Every function provided comes with example usage.
+- Great documentation, with examples for almost every function provided.
 - Prioritise simplicity at the cost of verbosity.
-- Be iterator-centric. Where applicable, combinators return iterators, so you can lean on the [`Iterator`]
-  interface to parse as much or as little as you want from the input, and collect up the output however
-  you wish.
+- Be iterator-centric. Where applicable, combinators return things which implement [`Tokens`]/[`Iterator`].
 - Allow user defined errors to be returned anywhere that it might make sense. Some functions have `_err`
   variants incase you need error information when they don't otherwise hand back errors for simplicity.
 - Location information should always be available, so that you can tell users where something went wrong.
-  see [`Tokens::offset`]
+  see [`Tokens::offset`] and [`Tokens::location()`].
 - Backtracking by default. Coming from Haskell's Parsec, this feels like the sensible default. It means that
-  if one of the provided parsing functions fails to parse what you asked for, it won't consume any input
-  trying.
+  if one of the provided parsing functions fails to parse something, it won't consume any input trying.
 - Expose all of the "low level" functions. You can save and rewind to locations as needed (see [`Tokens::location`]),
   and implement any of the provided functions using these primitives.
-- Aims to be "fairly quick". Avoids allocations (and allows you to do the same via the iterator-centric interface).
-  If you need "as fast as you can get", there are probably quicker alternatives.
+- Aims to be "fairly quick". Avoids allocations (and allows you to do the same via the iterator-centric interface)
+  almost everywhere. If you need "as fast as you can get", there amay be quicker alternatives.
 
 Have a look at the [`Tokens`] trait for all of the parsing methods made available, and examples for each.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,11 +111,12 @@ assert_eq!(remaining, ",foobar");
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+mod chars;
 mod tokens;
 
 #[doc(hidden)]
 pub mod one_of;
 
-pub mod chars;
 pub mod types;
+pub use chars::CharTokens;
 pub use tokens::{IntoTokens, TokenLocation, Tokens};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,8 +111,10 @@ assert_eq!(remaining, ",foobar");
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-mod one_of;
 mod tokens;
+
+#[doc(hidden)]
+pub mod one_of;
 
 pub mod chars;
 pub mod types;

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -1,8 +1,9 @@
-//! This module contains the core [`Tokens`] trait, which adds various convenience methods
-//! to the standard [`Iterator`] interface aimed at making it easy to parse the input.
+//! The point of this library. This module contains the core [`Tokens`] trait, which adds
+//! various convenience methods on top of an [`Iterator`] based interface aimed at making
+//! it easy to parse things.
 //!
-//! The [`IntoTokens`] trait is implemented for types that can be converted into something
-//! implementing the [`Tokens`] trait (for example `&str` and `&[T]`).
+//! The [`IntoTokens`] trait is also provided, and can be implemented for types that can be
+//! converted into something implementing the [`Tokens`] trait (for example `&str` and `&[T]`).
 mod many;
 mod many_err;
 mod sep_by;

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -954,7 +954,7 @@ pub trait Tokens: Sized {
         Output: crate::one_of::IsMatch,
     {
         let location = self.location();
-        if let Some(output) = f(self).is_match() {
+        if let Some(output) = f(self).into_match() {
             output
         } else {
             self.set_location(location);


### PR DESCRIPTION
- add `chars::float` to parse floats
- add `chars::case_insensitive_eq` for case insensitive token matching.
- generalise `one_of` and `.optional()`; allow expressions passed to either to return Options or bools, not just Options.